### PR TITLE
Move render/2 definition to Appsignal.Phoenix.View.__before_compile__/1 

### DIFF
--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -34,6 +34,8 @@ defmodule Appsignal.Phoenix.View do
     quote do
       @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
 
+      defoverridable [render: 2]
+
       def render(template, assigns) do
         {root, _pattern, _names} = __templates__()
         path = Path.join(root, template)

--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -32,9 +32,15 @@ defmodule Appsignal.Phoenix.View do
   """
   defmacro __using__(_) do
     quote do
+      @before_compile Appsignal.Phoenix.View
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
       @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
 
-      defoverridable [render: 2]
+      defoverridable render: 2
 
       def render(template, assigns) do
         {root, _pattern, _names} = __templates__()
@@ -43,7 +49,7 @@ defmodule Appsignal.Phoenix.View do
         Appsignal.instrument("Render #{path}", fn span ->
           @span.set_attribute(span, "title", path)
           @span.set_attribute(span, "appsignal:category", "render.phoenix_template")
-          render_template(template, assigns)
+          super(template, assigns)
         end)
       end
     end


### PR DESCRIPTION
This patch clears warnings with apps that have an overridden `render/2` function.