### PR TITLE
Add clause for non-binary template names in AppsignalPhoenix.View

### DIFF
--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -45,7 +45,7 @@ defmodule Appsignal.Phoenix.View do
 
       defoverridable render: 2
 
-      def render(template, assigns) do
+      def render(template, assigns) when is_binary(template) do
         {root, _pattern, _names} = __templates__()
         path = Path.join(root, template)
 
@@ -54,6 +54,10 @@ defmodule Appsignal.Phoenix.View do
           @span.set_attribute(span, "appsignal:category", "render.phoenix_template")
           super(template, assigns)
         end)
+      end
+
+      def render(template, assigns) do
+        super(template, assigns)
       end
     end
   end

--- a/test/appsignal_phoenix/view_test.exs
+++ b/test/appsignal_phoenix/view_test.exs
@@ -6,31 +6,67 @@ defmodule Appsignal.ViewTest do
     Test.Tracer.start_link()
     Test.Span.start_link()
 
-    %{return: PhoenixWeb.View.render("index.html", %{})}
+    :ok
   end
 
-  test "creates a root span" do
-    assert {:ok, [{_, nil}]} = Test.Tracer.get(:create_span)
+  describe "when calling render/2 with a binary first argument" do
+    setup do
+      %{return: PhoenixWeb.View.render("index.html", %{})}
+    end
+
+    test "creates a root span" do
+      assert {:ok, [{_, nil}]} = Test.Tracer.get(:create_span)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "Render test/support/index.html"}]} = Test.Span.get(:set_name)
+    end
+
+    test "sets the span's category" do
+      assert attribute("appsignal:category", "render.phoenix_template")
+    end
+
+    test "sets the span's title attribute" do
+      assert attribute("title", "test/support/index.html")
+    end
+
+    test "renders the template", %{return: return} do
+      assert {:safe, ["<h1>Welcome to ", "Phoenix", "!</h1>\n"]} = return
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
   end
 
-  test "sets the span's name" do
-    assert {:ok, [{%Span{}, "Render test/support/index.html"}]} = Test.Span.get(:set_name)
-  end
+  describe "when calling render/2 with a non-binary first argument" do
+    setup do
+      %{return: PhoenixWeb.View.render(PhoenixWeb.View, "index.html")}
+    end
 
-  test "sets the span's category" do
-    assert attribute("appsignal:category", "render.phoenix_template")
-  end
+    test "creates a root span" do
+      assert {:ok, [{_, nil}]} = Test.Tracer.get(:create_span)
+    end
 
-  test "sets the span's title attribute" do
-    assert attribute("title", "test/support/index.html")
-  end
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "Render test/support/index.html"}]} = Test.Span.get(:set_name)
+    end
 
-  test "renders the template", %{return: return} do
-    assert {:safe, ["<h1>Welcome to ", "Phoenix", "!</h1>\n"]} = return
-  end
+    test "sets the span's category" do
+      assert attribute("appsignal:category", "render.phoenix_template")
+    end
 
-  test "closes the span" do
-    assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    test "sets the span's title attribute" do
+      assert attribute("title", "test/support/index.html")
+    end
+
+    test "renders the template", %{return: return} do
+      assert {:safe, ["<h1>Welcome to ", "Phoenix", "!</h1>\n"]} = return
+    end
+
+    test "closes the span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
   end
 
   defp attribute(asserted_key, asserted_data) do


### PR DESCRIPTION
Closes https://github.com/appsignal/appsignal-elixir-phoenix/issues/5.
Closes https://github.com/appsignal/appsignal-elixir/issues/588.

Phoenix.View.render/2 can be called with a module name as the first argument,
causing the call to be redirected to Phoenix.View.render/3. This patch makes
sure we let the call go through unchanged, which prevents double
instrumentation from happening and fixes the reported dialyzer issues.

This is planned to be released as 2.0.1