### PR TITLE
Explicitly ignore returns from Span functions

### DIFF
--- a/lib/appsignal_phoenix/application.ex
+++ b/lib/appsignal_phoenix/application.ex
@@ -6,7 +6,7 @@ defmodule Appsignal.Phoenix.Application do
   use Application
 
   def start(_type, _args) do
-    EventHandler.attach()
+    _ = EventHandler.attach()
 
     opts = [strategy: :one_for_one, name: Appsignal.Phoenix.Supervisor]
     Supervisor.start_link([], opts)

--- a/lib/appsignal_phoenix/channel.ex
+++ b/lib/appsignal_phoenix/channel.ex
@@ -39,7 +39,7 @@ defmodule Appsignal.Phoenix.Channel do
     Appsignal.instrument(
       "#{Appsignal.Utils.module_name(module)}##{name}",
       fn span ->
-        @span.set_namespace(span, "channel")
+        _ = @span.set_namespace(span, "channel")
 
         try do
           fun.()
@@ -47,19 +47,21 @@ defmodule Appsignal.Phoenix.Channel do
           kind, reason ->
             stack = __STACKTRACE__
 
-            span
-            |> @span.set_sample_data("params", params)
-            |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
-            |> @span.add_error(kind, reason, stack)
-            |> @tracer.close_span()
+            _ =
+              span
+              |> @span.set_sample_data("params", params)
+              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+              |> @span.add_error(kind, reason, stack)
+              |> @tracer.close_span()
 
             @tracer.ignore()
             :erlang.raise(kind, reason, stack)
         else
           result ->
-            span
-            |> @span.set_sample_data("params", params)
-            |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+            _ =
+              span
+              |> @span.set_sample_data("params", params)
+              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
 
             result
         end

--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -50,8 +50,11 @@ defmodule Appsignal.Phoenix.View do
         path = Path.join(root, template)
 
         Appsignal.instrument("Render #{path}", fn span ->
-          @span.set_attribute(span, "title", path)
-          @span.set_attribute(span, "appsignal:category", "render.phoenix_template")
+          _ =
+            span
+            |> @span.set_attribute("title", path)
+            |> @span.set_attribute("appsignal:category", "render.phoenix_template")
+
           super(template, assigns)
         end)
       end

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,8 @@ defmodule Appsignal.Phoenix.MixProject do
       dialyzer: [
         ignore_warnings: "dialyzer.ignore-warnings",
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
-        plt_add_apps: [:phoenix_live_view]
+        plt_add_apps: [:phoenix_live_view],
+        flags: ["-Wunmatched_returns", "-Werror_handling", "-Wunderspecs"]
       ]
     ]
   end


### PR DESCRIPTION
Since the `Span.set_attribute/3` function takes and returns `Span`s and `nil`s,
we don't care about the return value here, as either case is accounted for.

The Application starts the EventHandler, which logs errors itself. Since we
don't do anyhthing else there, we don't need to catch the return.

Part of closing #5.