### PR TITLE
Use “live_view” namespace for LiveView samples

### DIFF
--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -1,6 +1,44 @@
 defmodule Appsignal.Phoenix.LiveView do
-  defdelegate instrument(module, name, socket, fun), to: Appsignal.Phoenix.Channel
-  defdelegate instrument(module, name, params, socket, fun), to: Appsignal.Phoenix.Channel
+  @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+
+  def instrument(module, name, socket, fun) do
+    instrument(module, name, %{}, socket, fun)
+  end
+
+  def instrument(module, name, params, socket, fun) do
+    Appsignal.instrument(
+      "#{Appsignal.Utils.module_name(module)}##{name}",
+      fn span ->
+        _ = @span.set_namespace(span, "channel")
+
+        try do
+          fun.()
+        catch
+          kind, reason ->
+            stack = __STACKTRACE__
+
+            _ =
+              span
+              |> @span.set_sample_data("params", params)
+              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+              |> @span.add_error(kind, reason, stack)
+              |> @tracer.close_span()
+
+            @tracer.ignore()
+            :erlang.raise(kind, reason, stack)
+        else
+          result ->
+            _ =
+              span
+              |> @span.set_sample_data("params", params)
+              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+
+            result
+        end
+      end
+    )
+  end
 
   def live_view_action(module, name, socket, function) do
     instrument(module, name, socket, function)

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -10,7 +10,7 @@ defmodule Appsignal.Phoenix.LiveView do
     Appsignal.instrument(
       "#{Appsignal.Utils.module_name(module)}##{name}",
       fn span ->
-        _ = @span.set_namespace(span, "channel")
+        _ = @span.set_namespace(span, "live_view")
 
         try do
           fun.()

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -35,7 +35,7 @@ defmodule Appsignal.Phoenix.LiveViewTest do
     end
 
     test "sets the span's namespace" do
-      assert {:ok, [{%Span{}, "channel"}]} = Test.Span.get(:set_namespace)
+      assert {:ok, [{%Span{}, "live_view"}]} = Test.Span.get(:set_namespace)
     end
 
     test "sets the span's sample data" do
@@ -71,7 +71,7 @@ defmodule Appsignal.Phoenix.LiveViewTest do
     end
 
     test "sets the span's namespace" do
-      assert {:ok, [{%Span{}, "channel"}]} = Test.Span.get(:set_namespace)
+      assert {:ok, [{%Span{}, "live_view"}]} = Test.Span.get(:set_namespace)
     end
 
     test "sets the span's parameters" do
@@ -111,7 +111,7 @@ defmodule Appsignal.Phoenix.LiveViewTest do
     end
 
     test "sets the span's namespace" do
-      assert {:ok, [{%Span{}, "channel"}]} = Test.Span.get(:set_namespace)
+      assert {:ok, [{%Span{}, "live_view"}]} = Test.Span.get(:set_namespace)
     end
 
     test "sets the span's parameters" do


### PR DESCRIPTION
Since the LiveView instrumentation used the channels instrumentation, the namespaces were set to “channel” instead of “live_view”, as in the documentation. This patch duplicates the channel instrumentation to update the namespace.

To test this, call an instrumented LiveView action in a Phoenix app while running this version of the library. Your dependency should look like this:

```
{:appsignal_phoenix, github: "appsignal/appsignal-elixir-phoenix", branch: "live_view_namespace"}
```