### PR TITLE
Exposes live_view_action/5 to help instrument handle_params

### DIFF
--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -43,4 +43,8 @@ defmodule Appsignal.Phoenix.LiveView do
   def live_view_action(module, name, socket, function) do
     instrument(module, name, socket, function)
   end
+
+  def live_view_action(module, name, params, socket, function) do
+    instrument(module, name, params, socket, function)
+  end
 end


### PR DESCRIPTION
This PR Adds live_view_action/5. Its appears a perfect fit for https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#c:handle_params/3

(Not sure why it was excluded from you API in the first place? I'm assuming https://docs.appsignal.com/guides/filter-data/filter-parameters.html#elixir-appsignal-parameter-filtering still works?)