### PR TITLE
Use Appsignal.Logger in Appsignal.Phoenix.View and .EventHandler

### DIFF
--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -14,7 +14,7 @@ defmodule Appsignal.Phoenix.EventHandler do
     for {event, fun} <- handlers do
       case :telemetry.attach({__MODULE__, event}, event, fun, :ok) do
         :ok ->
-          Logger.debug("Appsignal.Phoenix.EventHandler attached to #{inspect(event)}")
+          Appsignal.Logger.debug("Appsignal.Phoenix.EventHandler attached to #{inspect(event)}")
           :ok
 
         {:error, _} = error ->

--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -32,8 +32,7 @@ defmodule Appsignal.Phoenix.View do
   """
   defmacro __using__(_) do
     quote do
-      require Logger
-      Logger.debug("AppSignal.Phoenix.View attached to #{__MODULE__}")
+      Appsignal.Logger.debug("AppSignal.Phoenix.View attached to #{__MODULE__}")
 
       @before_compile Appsignal.Phoenix.View
     end

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Appsignal.Phoenix.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:appsignal_plug, ">= 2.0.4 and < 3.0.0"},
+      {:appsignal_plug, ">= 2.0.8 and < 3.0.0"},
       {:phoenix, "~> 1.4"},
       {:phoenix_html, "~> 2.11", optional: true},
       {:phoenix_live_view, "~> 0.9", optional: true},


### PR DESCRIPTION
Part of https://github.com/appsignal/appsignal-elixir/issues/634, this patch is the -phoenix equivalent of https://github.com/appsignal/appsignal-elixir-plug/pull/11 and uses `Appsignal.Logger.debug/1` instead of `Logger.debug/1` to only send log lines to Elixir’s `Logger` when AppSignal’s `:debug` configuration is set to `true`.