### PR TITLE
Take root_view from private in LiveView handler 

### DIFF
--- a/.changesets/phoenix-liveview-socket-root_view
+++ b/.changesets/phoenix-liveview-socket-root_view
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+---
+
+Handle `root_view`s in phoenix_live_view 0.15.6 and up, which were made private
+in
+https://github.com/phoenixframework/phoenix_live_view/commit/8bb6f44554f22bf580048e20562b62dd6b26e2b5.

--- a/lib/appsignal_phoenix/metadata.ex
+++ b/lib/appsignal_phoenix/metadata.ex
@@ -17,11 +17,15 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     def metadata(%Phoenix.LiveView.Socket{} = socket) do
       %{
         "id" => Map.get(socket, :id),
-        "root_view" => Map.get(socket, :root_view),
+        "root_view" => root_view(socket),
         "view" => Map.get(socket, :view),
         "endpoint" => Map.get(socket, :endpoint),
         "router" => Map.get(socket, :router)
       }
+    end
+
+    defp root_view(socket) do
+      socket |> Map.get(:private, %{}) |> Map.get(:root_view) || Map.get(socket, :root_view)
     end
   end
 end

--- a/lib/appsignal_phoenix/metadata.ex
+++ b/lib/appsignal_phoenix/metadata.ex
@@ -1,13 +1,13 @@
 defimpl Appsignal.Metadata, for: Phoenix.Socket do
   def metadata(%Phoenix.Socket{} = socket) do
     %{
-      "channel" => socket[:channel],
-      "endpoint" => socket[:endpoint],
-      "handler" => socket[:handler],
-      "id" => socket[:id],
-      "ref" => socket[:ref],
-      "topic" => socket[:topic],
-      "transport" => socket[:transport]
+      "channel" => Map.get(socket, :channel),
+      "endpoint" => Map.get(socket, :endpoint),
+      "handler" => Map.get(socket, :handler),
+      "id" => Map.get(socket, :id),
+      "ref" => Map.get(socket, :ref),
+      "topic" => Map.get(socket, :topic),
+      "transport" => Map.get(socket, :transport)
     }
   end
 end
@@ -16,11 +16,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
   defimpl Appsignal.Metadata, for: Phoenix.LiveView.Socket do
     def metadata(%Phoenix.LiveView.Socket{} = socket) do
       %{
-        "id" => socket[:id],
-        "root_view" => socket[:root_view],
-        "view" => socket[:view],
-        "endpoint" => socket[:endpoint],
-        "router" => socket[:router]
+        "id" => Map.get(socket, :id),
+        "root_view" => Map.get(socket, :root_view),
+        "view" => Map.get(socket, :view),
+        "endpoint" => Map.get(socket, :endpoint),
+        "router" => Map.get(socket, :router)
       }
     end
   end

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -10,7 +10,9 @@ defmodule Appsignal.Phoenix.LiveViewTest do
       socket: %Phoenix.LiveView.Socket{
         endpoint: PhoenixWeb.Endpoint,
         id: 1,
-        root_view: PhoenixWeb.LiveView,
+        private: %{
+          root_view: PhoenixWeb.LiveView
+        },
         router: PhoenixWeb.Router,
         view: PhoenixWeb.LiveView
       }
@@ -50,6 +52,32 @@ defmodule Appsignal.Phoenix.LiveViewTest do
 
     test "closes the span" do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
+  describe "instrument/4, with a non-private root_view" do
+    setup %{socket: socket} do
+      %{
+        return:
+          PhoenixWeb.LiveView.mount(%{}, %{
+            __struct__: Phoenix.LiveView.Socket,
+            endpoint: PhoenixWeb.Endpoint,
+            id: 1,
+            root_view: PhoenixWeb.LiveView,
+            router: PhoenixWeb.Router,
+            view: PhoenixWeb.LiveView
+          })
+      }
+    end
+
+    test "sets the span's sample data" do
+      assert_sample_data("environment", %{
+        "endpoint" => PhoenixWeb.Endpoint,
+        "id" => 1,
+        "root_view" => PhoenixWeb.LiveView,
+        "router" => PhoenixWeb.Router,
+        "view" => PhoenixWeb.LiveView
+      })
     end
   end
 


### PR DESCRIPTION
In
phoenixframework/phoenix_live_view@8bb6f44,
the root_view key was made private. This patch makes sure the LiveView
instrumentation handles both cases.

Closes #15.