### PR TITLE
Add mono to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,25 @@
-# 2.0.7
+# AppSignal for Elixir Phoenix changelog
 
+## 2.0.7
 - [af399efc](https://github.com/appsignal/appsignal-elixir-phoenix/commit/af399efc8ad43ab7b93d34f848eb1df6d87c96ad) patch - Handle `root_view`s in phoenix_live_view 0.15.6 and up, which were made private in https://github.com/phoenixframework/phoenix_live_view/commit/8bb6f44554f22bf580048e20562b62dd6b26e2b5.
 
-# 2.0.6
+## 2.0.6
 * Use Appsignal.Logger in Appsignal.Phoenix.View and .EventHandler. PR #12
 
-# 2.0.5
+## 2.0.5
 * Exposes live_view_action/5 to help instrument handle_params. PR #11
 
-# 2.0.4
+## 2.0.4
 * Allow :appsignal_plug versions between 2.0.4 and 3.0.0
 
-# 2.0.3
+## 2.0.3
 * Use “live_view” namespace for LiveView samples. PR #10
 
-# 2.0.2
+## 2.0.2
 * Explicitly ignore returns from Span functions. PR #7
 
-# 2.0.1
+## 2.0.1
 * Add clause for non-binary template names in AppsignalPhoenix.View. PR #6
 
-# 2.0.0
+## 2.0.0
 * Initial release, extracted from appsignal-elixir 🎉

--- a/mono.yml
+++ b/mono.yml
@@ -1,0 +1,3 @@
+---
+language: elixir
+repo: "https://github.com/appsignal/appsignal-elixir-phoenix"


### PR DESCRIPTION
Use our own tooling for development in the Elixir integration repos.
https://github.com/appsignal/mono/
Follow the instructions on the mono README to install it locally.

Mono repo support for Elixir isn't 100% feature complete yet so we're
first adding it to every repo separately. Right now we'll use it for
changesets, changelogs and publishing the package.

I didn't add mono to the Semaphore CI test setup as it doesn't really
add anything there at this point. I also didn't add it to the main
Elixir package's CI yet either.

[skip review]