### PR TITLE
Only create template spans when a root span exists

### DIFF
--- a/.changesets/only-create-template-spans-when-a-root-span-exists.md
+++ b/.changesets/only-create-template-spans-when-a-root-span-exists.md
@@ -2,6 +2,4 @@
 bump: "patch"
 ---
 
-Currently, a root span is created when a template is rendered outside of an existing root span. This produces a span that doesn't have any context that has a unique span name.
-
-This patch makes sure `Appsignal.View` doesn't create root spans anymore, skipping any template renders that can't be added to any existing trace.
+Don't track Phoenix render template events without root spans. For live view a lot of template events were tracked as separate incidents, causing a lot noise on the incidents overview for an app. This patch makes sure `Appsignal.View` doesn't create root spans anymore, skipping any template renders that can't be added to any existing trace.

--- a/.changesets/only-create-template-spans-when-a-root-span-exists.md
+++ b/.changesets/only-create-template-spans-when-a-root-span-exists.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+---
+
+Currently, a root span is created when a template is rendered outside of an existing root span. This produces a span that doesn't have any context that has a unique span name.
+
+This patch makes sure `Appsignal.View` doesn't create root spans anymore, skipping any template renders that can't be added to any existing trace.


### PR DESCRIPTION
Let's take this `handle_event/3` as an example, which is instrumented
through our `Appsignal.Phoenix.LiveView.instrument/4` helper:

``` elixir
  @impl true
  def handle_event("suggest", %{"q" => query}, socket) do
    instrument(__MODULE__, "suggest", socket, fn ->
      {:noreply, assign(socket, results: search(query), query: query)}
    end)
  end
```

This handler updates the page by changing the assigns by updating the
socket.  When that happens, LiveView automatically rerenders the
template to show the new data, which AppSignal tracks through the
`Appsignal.View` module automatically.

Because this function is wrapped in an `instrument/4` call, a span
gets created when it's called.  There's no parent span here, so it
creates a "root span", which tells the integration to set the
namespace and other metadata.  When a root span is closed, it's
automatically sent over to AppSignal.

What we'd expect is that the rendered template gets added as a child
span inside the root span.  That would resolve the issue of it turning
up in the wrong namespace, as child spans are automatically nested
inside their roots.  However, that doesn't work right now, because the
root span is already closed when the template gets rendered.

Currently, a root span is created when a template is rendered outside
of an existing root span. This produces a span that doesn't have any
context that has a unique span name.

This patch makes sure `Appsignal.View` doesn't create root spans
anymore, skipping any template renders that can't be added to any
existing trace.

Closes https://github.com/appsignal/support/issues/143.