### PR TITLE
Ensure templates get rendered without root spans

### DIFF
--- a/.changesets/return-templates-when-appsignals-view-instrumentation-is-disabled.md
+++ b/.changesets/return-templates-when-appsignals-view-instrumentation-is-disabled.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+`Appsignal.View` returns templates when AppSignal's view instrumentation is disabled.

--- a/test/appsignal_phoenix/view_test.exs
+++ b/test/appsignal_phoenix/view_test.exs
@@ -17,6 +17,10 @@ defmodule Appsignal.ViewTest do
     test "does not create a root span" do
       assert :error = Test.Tracer.get(:create_span)
     end
+
+    test "renders the template", %{return: return} do
+      assert {:safe, ["<h1>Welcome to ", "Phoenix", "!</h1>\n"]} = return
+    end
   end
 
   describe "when a root span exist, calling render/2 with a binary first argument" do


### PR DESCRIPTION
A regression in 2.0.8 caused view renders that didn't have a root span
to fail to return the rendered template. This patch makes sure the
template is rendered even if AppSignal's template instrumentation is
disabled.

Closes https://github.com/appsignal/appsignal-elixir-phoenix/issues/20.