### PR TITLE
Restore is_binary/1 check in View.render/2

### DIFF
--- a/.changesets/resolve-duplicate-view-clause-warnings-from-appsignal-view.md
+++ b/.changesets/resolve-duplicate-view-clause-warnings-from-appsignal-view.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Resolve duplicate view clause warnings from Appsignal.View

--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -45,7 +45,7 @@ defmodule Appsignal.Phoenix.View do
 
       defoverridable render: 2
 
-      def render(template, assigns) do
+      def render(template, assigns) when is_binary(template) do
         {root, _pattern, _names} = __templates__()
         path = Path.join(root, template)
 

--- a/test/appsignal_phoenix/view_test.exs
+++ b/test/appsignal_phoenix/view_test.exs
@@ -60,7 +60,7 @@ defmodule Appsignal.ViewTest do
     setup do
       %{
         parent: Appsignal.Tracer.create_span("http_request"),
-        return: PhoenixWeb.View.render("index.html", %{})
+        return: PhoenixWeb.View.render(PhoenixWeb.View, "index.html")
       }
     end
 


### PR DESCRIPTION
The test for the `is_binary/1` check broke in a previous commit,
allowing this issue to go unnoticed. This patch restores the test to
actually call the `render/2` function with a non-binary first
argument, and resolves the duplicate clause warning appearing in apps
using `Appsignal.View`.

This patch resolves the warnings reported in https://github.com/appsignal/appsignal-elixir-phoenix/issues/20#issuecomment-881396763.