### PR TITLE
Update elixir version for CI linters

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,7 +23,7 @@ blocks:
       prologue:
         commands:
           - sem-version erlang 23.2
-          - sem-version elixir master
+          - sem-version elixir 1.11.3
           - elixir -v
           - checkout
           - mix local.rebar --force


### PR DESCRIPTION
Using master Elixir version for linter jobs isn't required and is prone
to breaking CI.

Co-authored-by: Jeff Kreeftmeijer <jeffkreeftmeijer@gmail.com>