### PR TITLE
Remove telemetry dependency

### DIFF
--- a/.changesets/remove-unneeded-telemetry-dependency.md
+++ b/.changesets/remove-unneeded-telemetry-dependency.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Remove unneeded telemetry dependency

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,6 @@ defmodule Appsignal.Phoenix.MixProject do
       {:phoenix, "~> 1.4"},
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},
       {:phoenix_live_view, "~> 0.9", optional: true},
-      {:telemetry, "~> 0.4"},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false}


### PR DESCRIPTION
[skip changeset]

Telemetry dependency is not needed for this library as it is already a dependency of appsignal-elixir, which this library depends on through appsignal-plug.

Has to be deployed before https://github.com/appsignal/appsignal-elixir/pull/664 to avoid conflicts.