### PR TITLE
Resolve mime dependency issue for Elixir 1.9

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,6 +42,18 @@ defmodule Appsignal.Phoenix.MixProject do
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
+    system_version = System.version()
+
+    mime_dependency =
+      if Mix.env() == :test || Mix.env() == :test_no_nif do
+        case Version.compare(system_version, "1.10.0") do
+          :lt -> [{:mime, "~> 1.0"}]
+          _ -> []
+        end
+      else
+        []
+      end
+
     [
       {:appsignal_plug, ">= 2.0.8 and < 3.0.0"},
       {:phoenix, "~> 1.4"},
@@ -50,6 +62,6 @@ defmodule Appsignal.Phoenix.MixProject do
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false}
-    ]
+    ] ++ mime_dependency
   end
 end


### PR DESCRIPTION
[skip changeset]

Mime is depended on by plug in all environments. CI
breaks on Elixir 1.9.4 if it picks mime 2.0.x. This patch explicitly
locks to mime ~> 1.0 on Elixir versions before 1.10.