### PR TITLE
Update ci builds versions

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,84 +18,76 @@ blocks:
           commands:
             - script/install_lintje
             - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
-        - name: mix compile --warnings-as-errors
-          commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
-            - mix compile --warnings-as-errors
         - name: mix format --check-formatted
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
             - mix format --check-formatted
         - name: mix credo --strict
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
             - mix credo --strict
         - name: mix dialyzer
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
             - cache restore dialyzer-plt
             - MIX_ENV=dev mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
             - MIX_ENV=dev mix dialyzer
         - name: Elixir master, OTP 24
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master bin/setup
             - mix test
-        - name: Elixir master, OTP 24, without the NIF loaded
-          commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master . bin/setup
-            - MIX_ENV=test_no_nif mix test
         - name: Elixir 1.12.2, OTP 24
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
             - mix test
         - name: Elixir 1.12.2, OTP 23
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.2 bin/setup
             - mix test
         - name: Elixir 1.12.2, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.2 bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 24
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 . bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 23
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 21
           commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 23
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 21
           commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 . bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 21
           commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 . bin/setup
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 20
           commands:
-            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 . bin/setup
+            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 bin/setup
             - mix test
       env_vars:
         - name: MIX_ENV

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,157 +5,97 @@ agent:
     type: e1-standard-2
     os_image: ubuntu1804
 blocks:
-  - name: Run other linters
-    dependencies: []
-    task:
-      env_vars:
-        - name: LINTJE_VERSION
-          value: "0.3.0"
-      jobs:
-        - name: Git Lint (Lintje)
-          commands:
-            - checkout
-            - script/install_lintje
-            - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
-  - name: Run Elixir linters
-    dependencies: []
+  - name: Run linters and tests
     task:
       prologue:
         commands:
-          - sem-version erlang 23.2
-          - sem-version elixir 1.11.3
-          - elixir -v
           - checkout
-          - mix local.rebar --force
-          - mix local.hex --force
-          - mix deps.get
-
       jobs:
+        - name: Git Lint (Lintje)
+          env_vars:
+            - name: LINTJE_VERSION
+              value: "0.3.0"
+          commands:
+            - script/install_lintje
+            - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
+        - name: mix compile --warnings-as-errors
+          commands:
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
+            - mix compile --warnings-as-errors
         - name: mix format --check-formatted
           commands:
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix format --check-formatted
         - name: mix credo --strict
           commands:
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix credo --strict
         - name: mix dialyzer
           commands:
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
             - cache restore dialyzer-plt
-            - mix dialyzer --plt
+            - MIX_ENV=dev mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
-            - mix dialyzer
-  - name: Run tests
-    dependencies: []
-    task:
-      jobs:
-        - name: Elixir master, OTP 23
+            - MIX_ENV=dev mix dialyzer
+        - name: Elixir master, OTP 24
           commands:
-            - sem-version erlang 23.2
-            - sem-version elixir master
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master . bin/setup
             - mix test
-        - name: Elixir master, OTP 22
+        - name: Elixir master, OTP 24, without the NIF loaded
           commands:
-            - sem-version erlang 22.3
-            - sem-version elixir master
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master . bin/setup
+            - MIX_ENV=test_no_nif mix test
+        - name: Elixir 1.12.2, OTP 24
+          commands:
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix test
-        - name: Elixir 1.11.3, OTP 23
+        - name: Elixir 1.12.2, OTP 23
           commands:
-            - sem-version erlang 23.2
-            - sem-version elixir 1.11.3
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix test
-        - name: Elixir 1.11.3, OTP 22
+        - name: Elixir 1.12.2, OTP 22
           commands:
-            - sem-version erlang 22.3
-            - sem-version elixir 1.11.3
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix test
-        - name: Elixir 1.11.3, OTP 21
+        - name: Elixir 1.11.4, OTP 24
           commands:
-            - sem-version erlang 21.3
-            - sem-version elixir 1.11.3
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 . bin/setup
+            - mix test
+        - name: Elixir 1.11.4, OTP 23
+          commands:
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - mix test
+        - name: Elixir 1.11.4, OTP 22
+          commands:
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - mix test
+        - name: Elixir 1.11.4, OTP 21
+          commands:
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 . bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 23
           commands:
-            - sem-version erlang 23.2
-            - sem-version elixir 1.10.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 22
           commands:
-            - sem-version erlang 22.3
-            - sem-version elixir 1.10.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 21
           commands:
-            - sem-version erlang 21.3
-            - sem-version elixir 1.10.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 22
           commands:
-            - sem-version erlang 22.3
-            - sem-version elixir 1.9.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 21
           commands:
-            - sem-version erlang 21.3
-            - sem-version elixir 1.9.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 20
           commands:
-            - sem-version erlang 20.3
-            - sem-version elixir 1.9.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix test
       env_vars:
         - name: MIX_ENV

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,11 @@
+if [[ $ELIXIR_VERSION == "master" ]]; then
+  kiex install $ELIXIR_VERSION
+fi
+
+sem-version erlang $ERLANG_VERSION
+erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
+sem-version elixir $ELIXIR_VERSION
+elixir -v
+mix local.rebar --force
+mix local.hex --force
+mix deps.get

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,6 +6,8 @@ if Mix.env() == :test do
   config :appsignal, appsignal_tracer: Appsignal.Test.Tracer
   config :appsignal, appsignal_span: Appsignal.Test.Span
 
+  config :phoenix, :json_library, Poison
+
   config :appsignal, :config,
     push_api_key: "00000000-0000-0000-0000-000000000000",
     name: "appsignal-plug",

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,8 @@ defmodule Appsignal.Phoenix.MixProject do
       {:phoenix_live_view, "~> 0.9", optional: true},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:credo, "~> 1.4", only: [:dev, :test], runtime: false}
+      {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
+      {:poison, "~> 5.0", only: [:dev, :test], runtime: false}
     ] ++ mime_dependency
   end
 end

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -1,6 +1,6 @@
 defmodule Appsignal.Phoenix.EventHandlerTest do
   use ExUnit.Case
-  alias Appsignal.{Phoenix, Span, Test, Tracer}
+  alias Appsignal.{Span, Test, Tracer}
 
   setup do
     start_supervised!(Test.Tracer)
@@ -34,40 +34,8 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     end
   end
 
-  defp attached?(event) do
-    event
-    |> :telemetry.list_handlers()
-    |> Enum.any?(fn %{id: id} ->
-      id == {Phoenix.EventHandler, event}
-    end)
-  end
-
   defp create_root_span(_context) do
     [span: Tracer.create_span("http_request")]
-  end
-
-  defp create_child_span(%{span: span}) do
-    [span: Tracer.create_span("http_request", span), parent: span]
-  end
-
-  defp router_dispatch_start_event(_context) do
-    do_router_dispatch_start_event()
-  end
-
-  defp do_router_dispatch_start_event(plug_opts \\ :index) do
-    :telemetry.execute(
-      [:phoenix, :router_dispatch, :start],
-      %{time: -576_460_736_044_040_000},
-      %{
-        conn: %Plug.Conn{},
-        log: :debug,
-        path_params: %{},
-        pipe_through: [:browser],
-        plug: AppsignalPhoenixExampleWeb.PageController,
-        plug_opts: plug_opts,
-        route: "/"
-      }
-    )
   end
 
   def endpoint_start_event(_context) do

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -73,7 +73,7 @@ defmodule Appsignal.Phoenix.LiveViewTest do
   end
 
   describe "instrument/4, with a non-private root_view" do
-    setup %{socket: socket} do
+    setup %{socket: _socket} do
       %{
         return:
           PhoenixWeb.LiveView.mount(%{}, %{

--- a/test/appsignal_phoenix_test.exs
+++ b/test/appsignal_phoenix_test.exs
@@ -102,7 +102,7 @@ defmodule Appsignal.PhoenixTest do
       assert :error = Test.Span.get(:set_name)
     end
 
-    test "adds an error to the span", %{reason: reason} do
+    test "adds an error to the span", %{reason: _reason} do
       assert :error = Test.Span.get(:add_error)
     end
 

--- a/test/support/phoenix_web.ex
+++ b/test/support/phoenix_web.ex
@@ -82,6 +82,12 @@ defmodule PhoenixWeb.LiveView do
       {:ok, socket}
     end)
   end
+
+  def render(assigns) do
+    ~H"""
+    Hello World
+    """
+  end
 end
 
 defmodule PhoenixWeb.ErrorView do


### PR DESCRIPTION
[skip changeset]

# Update CI build versions
CI was running with older versions of OTP and Elixir. Updated it to work
as the Elixir library.

# Remove compilation warnings
We are adding a compilation step on CI with warnings as errors. We have
to get rid of them to make the build pass.