### PR TITLE
Telemetry module capture

### DIFF
--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -7,8 +7,8 @@ defmodule Appsignal.Phoenix.EventHandler do
 
   def attach do
     handlers = %{
-      [:phoenix, :endpoint, :start] => &phoenix_endpoint_start/4,
-      [:phoenix, :endpoint, :stop] => &phoenix_endpoint_stop/4
+      [:phoenix, :endpoint, :start] => &__MODULE__.phoenix_endpoint_start/4,
+      [:phoenix, :endpoint, :stop] => &__MODULE__.phoenix_endpoint_stop/4
     }
 
     for {event, fun} <- handlers do
@@ -41,7 +41,7 @@ defmodule Appsignal.Phoenix.EventHandler do
     |> @span.set_attribute("appsignal:category", "call.phoenix_endpoint")
   end
 
-  defp phoenix_endpoint_stop(_event, _measurements, _metadata, _config) do
+  def phoenix_endpoint_stop(_event, _measurements, _metadata, _config) do
     @tracer.close_span(@tracer.current_span())
   end
 


### PR DESCRIPTION
## Motivation

After upgrading to telemetry 1.0 I started seeing the following warnings.

```
16:12:45.974 [info] Function passed as a handler with ID {Appsignal.Phoenix.EventHandler, [:phoenix, :endpoint, :start]} is local function.
This mean that it is either anonymous function or capture of function without module specified. That may cause performance penalty when calling such handler. For more details see note in `telemetry:attach/4` documentation.

16:12:45.980 [info] Function passed as a handler with ID {Appsignal.Phoenix.EventHandler, [:phoenix, :endpoint, :stop]} is local function.
This mean that it is either anonymous function or capture of function without module specified. That may cause performance penalty when calling such handler. For more details see note in `telemetry:attach/4` documentation.
```


## Proposed solution

Use function captures with the module specified in the call to `:telemetry.attach/4` 

Ref https://hexdocs.pm/telemetry/telemetry.html#attach/4
