### PR TITLE
Specify the module for Phoenix handlers

### DIFF
--- a/.changesets/fix-telemetry-1-x-warning-caused-by-the-phoenix-eventhandler.md
+++ b/.changesets/fix-telemetry-1-x-warning-caused-by-the-phoenix-eventhandler.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix Telemetry 1.x warning caused by the Phoenix EventHandler

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -7,8 +7,8 @@ defmodule Appsignal.Phoenix.EventHandler do
 
   def attach do
     handlers = %{
-      [:phoenix, :endpoint, :start] => &phoenix_endpoint_start/4,
-      [:phoenix, :endpoint, :stop] => &phoenix_endpoint_stop/4
+      [:phoenix, :endpoint, :start] => &__MODULE__.phoenix_endpoint_start/4,
+      [:phoenix, :endpoint, :stop] => &__MODULE__.phoenix_endpoint_stop/4
     }
 
     for {event, fun} <- handlers do
@@ -41,7 +41,7 @@ defmodule Appsignal.Phoenix.EventHandler do
     |> @span.set_attribute("appsignal:category", "call.phoenix_endpoint")
   end
 
-  defp phoenix_endpoint_stop(_event, _measurements, _metadata, _config) do
+  def phoenix_endpoint_stop(_event, _measurements, _metadata, _config) do
     @tracer.close_span(@tracer.current_span())
   end
 


### PR DESCRIPTION
Upgrading a Phoenix app with AppSignal to Telemetry 1.x produces the
following message printed to the console:

    [info] Function passed as a handler with ID
    {Appsignal.Phoenix.EventHandler, [:phoenix, :endpoint, :stop]} is
    local function.  This mean that it is either anonymous function or
    capture of function without module specified. That may cause
    performance penalty when calling such handler. For more details see
    note in `telemetry:attach/4`

This patch prefixes the function reference with the module name to
silence this warning.

Note: This is based on #32, with an added changelog and an updated commit message.