### PR TITLE
Replace uses of `set_sample_data`

### DIFF
--- a/lib/appsignal_phoenix/channel.ex
+++ b/lib/appsignal_phoenix/channel.ex
@@ -30,6 +30,7 @@ defmodule Appsignal.Phoenix.Channel do
 
   @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+  alias Appsignal.Utils.MapFilter
 
   def instrument(module, name, socket, fun) do
     instrument(module, name, %{}, socket, fun)
@@ -47,10 +48,11 @@ defmodule Appsignal.Phoenix.Channel do
           kind, reason ->
             stack = __STACKTRACE__
 
+            @tracer.set_params(MapFilter.filter(params))
+            @tracer.set_environment(Appsignal.Metadata.metadata(socket))
+
             _ =
               span
-              |> @span.set_sample_data("params", params)
-              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
               |> @span.add_error(kind, reason, stack)
               |> @tracer.close_span()
 
@@ -58,10 +60,8 @@ defmodule Appsignal.Phoenix.Channel do
             :erlang.raise(kind, reason, stack)
         else
           result ->
-            _ =
-              span
-              |> @span.set_sample_data("params", params)
-              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+            @tracer.set_params(MapFilter.filter(params))
+            @tracer.set_environment(Appsignal.Metadata.metadata(socket))
 
             result
         end

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     [
-      {:appsignal_plug, ">= 2.0.8 and < 3.0.0"},
+      {:appsignal_plug, ">= 2.0.9 and < 3.0.0"},
       {:phoenix, "~> 1.4"},
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},
       {:phoenix_live_view, "~> 0.9", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,11 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     [
-      {:appsignal_plug, ">= 2.0.9 and < 3.0.0"},
+      {
+        :appsignal_plug,
+        ">= 2.0.8 and < 3.0.0",
+        github: "appsignal/appsignal-elixir-plug", branch: "replace-set-sample-data"
+      },
       {:phoenix, "~> 1.4"},
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},
       {:phoenix_live_view, "~> 0.9", optional: true},

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -40,8 +40,8 @@ defmodule Appsignal.Phoenix.LiveViewTest do
       assert {:ok, [{%Span{}, "live_view"}]} = Test.Span.get(:set_namespace)
     end
 
-    test "sets the span's sample data" do
-      assert_sample_data("environment", %{
+    test "sets the span's environment" do
+      assert_environment(%{
         "endpoint" => PhoenixWeb.Endpoint,
         "id" => 1,
         "root_view" => PhoenixWeb.LiveView,
@@ -87,8 +87,8 @@ defmodule Appsignal.Phoenix.LiveViewTest do
       }
     end
 
-    test "sets the span's sample data" do
-      assert_sample_data("environment", %{
+    test "sets the span's environment" do
+      assert_environment(%{
         "endpoint" => PhoenixWeb.Endpoint,
         "id" => 1,
         "root_view" => PhoenixWeb.LiveView,
@@ -120,11 +120,11 @@ defmodule Appsignal.Phoenix.LiveViewTest do
     end
 
     test "sets the span's parameters" do
-      assert_sample_data("params", %{"body" => "Hello world!"})
+      assert_params(%{"body" => "Hello world!"})
     end
 
-    test "sets the span's sample data" do
-      assert_sample_data("environment", %{
+    test "sets the span's environment" do
+      assert_environment(%{
         "endpoint" => PhoenixWeb.Endpoint,
         "id" => 1,
         "root_view" => PhoenixWeb.LiveView,
@@ -135,6 +135,18 @@ defmodule Appsignal.Phoenix.LiveViewTest do
 
     test "closes the span" do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
+  describe "instrument/5, when filter_parameters is set" do
+    setup %{socket: socket} do
+      Application.put_env(:phoenix, :filter_parameters, {:keep, ["body"]})
+      PhoenixWeb.LiveView.mount(%{"body" => "Hello world!", "secret" => "hunter2"}, socket)
+      Application.delete_env(:phoenix, :filter_parameters)
+    end
+
+    test "filters the span's parameters" do
+      assert_params(%{"body" => "Hello world!", "secret" => "[FILTERED]"})
     end
   end
 
@@ -160,11 +172,11 @@ defmodule Appsignal.Phoenix.LiveViewTest do
     end
 
     test "sets the span's parameters" do
-      assert_sample_data("params", %{"body" => "Exception!"})
+      assert_params(%{"body" => "Exception!"})
     end
 
-    test "sets the span's sample data" do
-      assert_sample_data("environment", %{
+    test "sets the span's environment" do
+      assert_environment(%{
         "endpoint" => PhoenixWeb.Endpoint,
         "id" => 1,
         "root_view" => PhoenixWeb.LiveView,
@@ -191,11 +203,34 @@ defmodule Appsignal.Phoenix.LiveViewTest do
     end
   end
 
-  defp assert_sample_data(asserted_key, asserted_data) do
-    {:ok, sample_data} = Test.Span.get(:set_sample_data)
+  describe "instrument/5, when an error is raised and filter_parameters is set" do
+    setup %{socket: socket} do
+      try do
+        Application.put_env(:phoenix, :filter_parameters, {:keep, ["body"]})
+        PhoenixWeb.LiveView.mount(%{"body" => "Exception!", "secret" => "hunter2"}, socket)
+      catch
+        _kind, _reason -> Application.delete_env(:phoenix, :filter_parameters)
+      end
+    end
 
-    assert Enum.any?(sample_data, fn {%Span{}, key, data} ->
-             key == asserted_key and data == asserted_data
+    test "filters the span's parameters" do
+      assert_params(%{"body" => "Exception!", "secret" => "[FILTERED]"})
+    end
+  end
+
+  defp assert_environment(asserted_data) do
+    {:ok, environment} = Test.Tracer.get(:set_environment)
+
+    assert Enum.any?(environment, fn {data} ->
+             data == asserted_data
+           end)
+  end
+
+  defp assert_params(asserted_data) do
+    {:ok, params} = Test.Tracer.get(:set_params)
+
+    assert Enum.any?(params, fn {data} ->
+             data == asserted_data
            end)
   end
 end


### PR DESCRIPTION
[skip changeset]

Do not merge before appsignal/appsignal-elixir#713 and appsignal/appsignal-elixir-plug#20.

### Replace uses of set_sample_data

Since `set_sample_data/3` is deprecated, usages of it have been replaced with `set_params/2` and `set_environment/2`.

### Point to the integration's branch

TODO:
- [ ] Rebase out this commit before merging, after the `deprecate-set-sample-data` and `replace-set-sample-data` branches have been merged to `main`.