### PR TITLE
Auto-Instrument Live Views

### DIFF
--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -1,7 +1,72 @@
 defmodule Appsignal.Phoenix.LiveView do
+  @moduledoc """
+  Instruments Phoenix live views and live components.
+
+  ## Usage
+
+  To automatically instrument a module with `Phoenix.LiveView` or `Phoenix.LiveComponent` callbacks,
+  add `use Appsignal.Phoenix.LiveView` to the module:
+
+      defmodule AppsignalPhoenixExampleWeb.ExampleLive do
+        use Appsignal.Phoenix.LiveView
+
+        def mount(params, session, socket) do
+          # ...
+        end
+      end
+
+  This will instrument many of the common callbacks used by these modules:
+
+    * `Phoenix.LiveView.mount/3`
+    * `Phoenix.LiveView.handle_event/3`
+    * `Phoenix.LiveView.handle_params/3`
+    * `Phoenix.LiveComponent.mount/1`
+    * `Phoenix.LiveComponent.update/2`
+
+  Alternatively, you can manually instrument functions in a live view or component using
+  `instrument/4`:
+
+      defmodule AppsignalPhoenixExampleWeb.ClockLive do
+        use Phoenix.LiveView
+        import Appsignal.Phoenix.LiveView, only: [instrument: 4]
+
+        def render(assigns) do
+          AppsignalPhoenixExampleWeb.ClockView.render("index.html", assigns)
+        end
+
+        def mount(_params, _session, socket) do
+          # Wrap the contents of the mount/2 function with a call to
+          # Appsignal.Phoenix.LiveView.instrument/4
+
+          instrument(__MODULE__, "mount", socket, fn ->
+            :timer.send_interval(1000, self(), :tick)
+            {:ok, assign(socket, state: Time.utc_now())}
+          end)
+        end
+
+        def handle_info(:tick, socket) do
+          # Wrap the contents of the handle_info/2 function with a call to
+          # Appsignal.Phoenix.LiveView.instrument/4:
+
+          instrument(__MODULE__, "tick", socket, fn ->
+            {:ok, assign(socket, state: Time.utc_now())}
+          end)
+        end
+      end
+
+  """
   @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
   @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
 
+  @doc false
+  defmacro __using__(_) do
+    quote do
+      use Appsignal.Phoenix.LiveView.AutoInstrument
+      @decorate_all instrument()
+    end
+  end
+
+  @doc false
   def instrument(module, name, socket, fun) do
     instrument(module, name, %{}, socket, fun)
   end

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -72,6 +72,8 @@ defmodule Appsignal.Phoenix.LiveView do
   end
 
   def instrument(module, name, params, socket, fun) do
+    environment = if socket, do: Appsignal.Metadata.metadata(socket), else: %{}
+
     Appsignal.instrument(
       "#{Appsignal.Utils.module_name(module)}##{name}",
       fn span ->
@@ -86,7 +88,7 @@ defmodule Appsignal.Phoenix.LiveView do
             _ =
               span
               |> @span.set_sample_data("params", params)
-              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+              |> @span.set_sample_data("environment", environment)
               |> @span.add_error(kind, reason, stack)
               |> @tracer.close_span()
 
@@ -97,7 +99,7 @@ defmodule Appsignal.Phoenix.LiveView do
             _ =
               span
               |> @span.set_sample_data("params", params)
-              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+              |> @span.set_sample_data("environment", environment)
 
             result
         end

--- a/lib/appsignal_phoenix/live_view/auto_instrument.ex
+++ b/lib/appsignal_phoenix/live_view/auto_instrument.ex
@@ -35,11 +35,10 @@ defmodule Appsignal.Phoenix.LiveView.AutoInstrument do
     do_instrument(module, :params, params, socket, body)
   end
 
-  # TODO: Provide implementation of Appsignal.Metadata for `nil` when socket is unavailable.
   # render(assigns)
-  # def instrument(body, %{module: module, name: :render, args: [_assigns]}) do
-  #   do_instrument(module, :render, %{}, nil, body)
-  # end
+  def instrument(body, %{module: module, name: :render, args: [_assigns]}) do
+    do_instrument(module, :render, %{}, nil, body)
+  end
 
   #
   # Phoenix.LiveComponent
@@ -50,11 +49,10 @@ defmodule Appsignal.Phoenix.LiveView.AutoInstrument do
     do_instrument(module, :mount, %{}, socket, body)
   end
 
-  # TODO: Provide implementation of Appsignal.Metadata for `nil` when socket is unavailable.
   # preload(assigns)
-  # def instrument(body, %{module: module, name: :preload, args: [_assigns]}) do
-  #   do_instrument(module, :preload, %{}, nil, body)
-  # end
+  def instrument(body, %{module: module, name: :preload, args: [_assigns]}) do
+    do_instrument(module, :preload, %{}, nil, body)
+  end
 
   # update(assigns, socket)
   def instrument(body, %{module: module, name: :upload, args: [_assigns, socket]}) do

--- a/lib/appsignal_phoenix/live_view/auto_instrument.ex
+++ b/lib/appsignal_phoenix/live_view/auto_instrument.ex
@@ -1,0 +1,83 @@
+defmodule Appsignal.Phoenix.LiveView.AutoInstrument do
+  @moduledoc false
+  use Decorator.Define, instrument: 0
+
+  # Provides instrumentation for common `Phoenix.LiveView` and `Phoenix.LiveComponent` callbacks.
+  #
+  # To use, call:
+  #
+  #   use Appsignal.Phoenix.LiveView.AutoInstrument
+  #   @decorate_all instrument()
+  #
+  def instrument(body, context)
+
+  #
+  # Phoenix.LiveView
+  #
+
+  # mount(params, session, socket) when params :: :not_mounted_at_router
+  def instrument(body, %{module: module, name: :mount, args: [:not_mounted_at_router, _, socket]}) do
+    do_instrument(module, :mount, %{}, socket, body)
+  end
+
+  # mount(params, session, socket) when params :: map
+  def instrument(body, %{module: module, name: :mount, args: [params, _session, socket]}) do
+    do_instrument(module, :mount, params, socket, body)
+  end
+
+  # handle_event(event, unsigned_params, socket)
+  def instrument(body, %{module: module, name: :handle_event, args: [event, params, socket]}) do
+    do_instrument(module, "event:#{event}", params, socket, body)
+  end
+
+  # handle_params(unsigned_params, uri, socket)
+  def instrument(body, %{module: module, name: :handle_params, args: [params, _uri, socket]}) do
+    do_instrument(module, :params, params, socket, body)
+  end
+
+  # TODO: Provide implementation of Appsignal.Metadata for `nil` when socket is unavailable.
+  # render(assigns)
+  # def instrument(body, %{module: module, name: :render, args: [_assigns]}) do
+  #   do_instrument(module, :render, %{}, nil, body)
+  # end
+
+  #
+  # Phoenix.LiveComponent
+  #
+
+  # mount(socket)
+  def instrument(body, %{module: module, name: :mount, args: [socket]}) do
+    do_instrument(module, :mount, %{}, socket, body)
+  end
+
+  # TODO: Provide implementation of Appsignal.Metadata for `nil` when socket is unavailable.
+  # preload(assigns)
+  # def instrument(body, %{module: module, name: :preload, args: [_assigns]}) do
+  #   do_instrument(module, :preload, %{}, nil, body)
+  # end
+
+  # update(assigns, socket)
+  def instrument(body, %{module: module, name: :upload, args: [_assigns, socket]}) do
+    do_instrument(module, :upload, %{}, socket, body)
+  end
+
+  #
+  # Fallback
+  #
+
+  # For non-callback functions, take no action.
+  def instrument(body, _), do: body
+
+  defp do_instrument(module, name, params, socket, body) do
+    # credo:disable-for-lines:2 Credo.Check.Design.AliasUsage
+    quote do
+      Appsignal.Phoenix.LiveView.instrument(
+        unquote(module),
+        unquote(name),
+        unquote(Macro.escape(params)),
+        unquote(socket),
+        fn -> unquote(body) end
+      )
+    end
+  end
+end


### PR DESCRIPTION
Hello there 👋🏼 

This PR has code attached, but it's mostly for discussion purposes. I recently needed to instrument some live views, and yearned for the simplicity of the plug-based integrations. My goal was to include a single line in each `LiveView` or `LiveComponent` and have it "just work."

This is what came of it. Personally, I think [Sergio Tapia's approach](https://sergiotapia.com/integrating-appsignal-with-phoenix-liveview-tutorial) (which you linked in #37) is **much better** in general, and worth exploring more. However, I also wanted to capture data from `mount`, `handle_params`, `update`, etc. and have the bodies of those functions fully wrapped.

The summary of the implementation is this:

* Use `@decorate_all` from `Decorator` to add the instrumentation
* Pattern match on function names and arguments to instrument only the LiveView and LiveComponent callbacks
* Because `Decorator` defines a `__using__/1` macro when you use it, we need a separate module to enclose the decorator function.

Regardless of this code's utility, I wanted to share my solution here in case it helps anyone else. Feel free to ignore and close this PR as you see fit. 🙂 