### PR TITLE
Use Appsignal.Utils.compile_env in Appsignal.Phoenix

### DIFF
--- a/lib/appsignal_phoenix/channel.ex
+++ b/lib/appsignal_phoenix/channel.ex
@@ -28,8 +28,9 @@ defmodule Appsignal.Phoenix.Channel do
 
   """
 
-  @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+  require Appsignal.Utils
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   def instrument(module, name, socket, fun) do
     instrument(module, name, %{}, socket, fun)

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -1,6 +1,7 @@
 defmodule Appsignal.Phoenix.EventHandler do
-  @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+  require Appsignal.Utils
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
   @moduledoc false
 
   require Logger

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -1,6 +1,7 @@
 defmodule Appsignal.Phoenix.LiveView do
-  @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+  require Appsignal.Utils
+  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   def instrument(module, name, socket, fun) do
     instrument(module, name, %{}, socket, fun)

--- a/lib/appsignal_phoenix/template.ex
+++ b/lib/appsignal_phoenix/template.ex
@@ -1,5 +1,6 @@
 defmodule Appsignal.Phoenix.Template do
-  @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
+  require Appsignal.Utils
+  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
   @moduledoc false
 
   def compile(fun, path) do

--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -40,8 +40,9 @@ defmodule Appsignal.Phoenix.View do
 
   defmacro __before_compile__(_env) do
     quote do
-      @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)
-      @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+      require Appsignal.Utils
+      @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+      @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
 
       defoverridable render: 2
 

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     [
-      {:appsignal_plug, ">= 2.0.8 and < 3.0.0"},
+      {:appsignal_plug, ">= 2.0.9 and < 3.0.0"},
       {:phoenix, "~> 1.4"},
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},
       {:phoenix_live_view, "~> 0.9", optional: true},


### PR DESCRIPTION
to avoid warnings on Elixir 1.14+