### PR TITLE
Add Missing live_component Handler

### DIFF
--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -100,6 +100,19 @@ defmodule Appsignal.Phoenix.LiveView do
     |> @span.set_sample_data("session_data", metadata[:session])
   end
 
+  def handle_event_start(
+        [:phoenix, :live_component, name, :start],
+        %{system_time: system_time},
+        metadata,
+        _event_name
+      ) do
+    "live_view"
+    |> @tracer.create_span(nil, start_time: system_time)
+    |> @span.set_name("#{Appsignal.Utils.module_name(metadata[:socket].view)}##{name}")
+    |> @span.set_attribute("appsignal:category", "#{name}.live_view")
+    |> @span.set_sample_data("params", metadata[:params])
+  end
+
   def handle_event_stop(_event, _params, _metadata, _event_name) do
     @tracer.close_span(@tracer.current_span(), end_time: @os.system_time())
   end

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -359,6 +359,54 @@ defmodule Appsignal.Phoenix.LiveViewTest do
     end
   end
 
+  describe "handle_event_start/4, with a live_component handle_event event" do
+    setup do
+      event = [:phoenix, :live_component, :handle_event, :start]
+
+      :telemetry.attach(
+        {__MODULE__, event},
+        event,
+        &Appsignal.Phoenix.LiveView.handle_event_start/4,
+        :ok
+      )
+
+      :telemetry.execute(
+        [:phoenix, :live_component, :handle_event, :start],
+        %{monotonic_time: -576_457_566_461_433_920, system_time: 1_653_474_764_790_125_080},
+        %{
+          params: %{foo: "bar"},
+          socket: %Phoenix.LiveView.Socket{view: __MODULE__}
+        }
+      )
+    end
+
+    test "creates a root span with a namespace and a start time" do
+      assert {:ok, [{"live_view", nil, [start_time: 1_653_474_764_790_125_080]}]} =
+               Test.Tracer.get(:create_span)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "Appsignal.Phoenix.LiveViewTest#handle_event"}]} =
+               Test.Span.get(:set_name)
+    end
+
+    test "sets the span's category" do
+      assert {:ok, attributes} = Test.Span.get(:set_attribute)
+
+      assert Enum.any?(attributes, fn {%Span{}, key, data} ->
+               key == "appsignal:category" and data == "handle_event.live_view"
+             end)
+    end
+
+    test "sets the span's params" do
+      assert {:ok, attributes} = Test.Span.get(:set_sample_data)
+
+      assert Enum.any?(attributes, fn {%Span{}, key, data} ->
+               key == "params" and data == %{foo: "bar"}
+             end)
+    end
+  end
+
   describe "handle_event_stop/4" do
     setup do
       event = [:phoenix, :live_view, :mount, :stop]


### PR DESCRIPTION
Hello 👋🏼 

After the introduction of `live_component` events to the automatic telemetry attachment, I noticed that the handler was being detached at runtime due to a function clause error. The current `handle_event_start/4` function does not accept `:live_component` events.

This PR adds another function clause (which is the same as the existing function clause **except** it does not track session data, as session data is not available in live components). It also adds copies of the relevant tests that exercise the function.

---

Original error:

```
21:15:01.209 [error] Handler {Appsignal.Phoenix.LiveView, [:phoenix, :live_component, :handle_event, :start]} has failed and has been detached. Class=:error
Reason=:function_clause
Stacktrace=[
  {Appsignal.Phoenix.LiveView, :handle_event_start,
   [
     [:phoenix, :live_component, :handle_event, :start],
     %{monotonic_time: -576460747140818208, system_time: 1656551701209609917},
     %{
       component: MyAppWeb.MyLive,
       event: "my_event",
       params: %{"my_value" => ""},
       socket: #Phoenix.LiveView.Socket<
         assigns: %{...} (truncated)
```