### PR TITLE
Add event names to LiveView instrumentation

### DIFF
--- a/.changesets/add-event-names-to-liveview-events.md
+++ b/.changesets/add-event-names-to-liveview-events.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add event names to LiveView events

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -96,6 +96,7 @@ defmodule Appsignal.Phoenix.LiveView do
     |> @tracer.create_span(nil, start_time: system_time)
     |> @span.set_name("#{Appsignal.Utils.module_name(metadata[:socket].view)}##{name}")
     |> @span.set_attribute("appsignal:category", "#{name}.live_view")
+    |> @span.set_attribute("event", metadata[:event])
     |> @span.set_sample_data("params", metadata[:params])
     |> @span.set_sample_data("session_data", metadata[:session])
   end

--- a/mix.exs
+++ b/mix.exs
@@ -54,6 +54,7 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     [
+      {:appsignal, ">= 2.2.15 and < 3.0.0"},
       {:appsignal_plug, ">= 2.0.11 and < 3.0.0"},
       {:phoenix, "~> 1.4"},
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -327,7 +327,8 @@ defmodule Appsignal.Phoenix.LiveViewTest do
         %{monotonic_time: -576_457_566_461_433_920, system_time: 1_653_474_764_790_125_080},
         %{
           params: %{foo: "bar"},
-          socket: %Phoenix.LiveView.Socket{view: __MODULE__}
+          socket: %Phoenix.LiveView.Socket{view: __MODULE__},
+          event: "event"
         }
       )
     end
@@ -347,6 +348,14 @@ defmodule Appsignal.Phoenix.LiveViewTest do
 
       assert Enum.any?(attributes, fn {%Span{}, key, data} ->
                key == "appsignal:category" and data == "handle_event.live_view"
+             end)
+    end
+
+    test "sets the span's event name" do
+      assert {:ok, attributes} = Test.Span.get(:set_attribute)
+
+      assert Enum.any?(attributes, fn {%Span{}, key, data} ->
+               key == "event" and data == "event"
              end)
     end
 


### PR DESCRIPTION
As requested in https://app.intercom.com/a/apps/yzor8gyw/inbox/inbox/conversation/16410700131606.

In handle_event_start/3, use the event name to add as the value for the
"event" attribute if it's set.

Because the changes in https://github.com/appsignal/appsignal-elixir-phoenix/commit/2eb6ec82f0edf3038815f9cfee59f0e030fc7c7c could
send nil values to Span.set_attribute/3 function, appsignal 2.2.15 or
above is required for that patch to work.