### PR TITLE
Add live_component handler to the LiveView integration

### DIFF
--- a/.changesets/handle-live_component-events-in-liveview-integration.md
+++ b/.changesets/handle-live_component-events-in-liveview-integration.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Handle live_component events in LiveView integration

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -101,6 +101,19 @@ defmodule Appsignal.Phoenix.LiveView do
     |> @span.set_sample_data("session_data", metadata[:session])
   end
 
+  def handle_event_start(
+        [:phoenix, :live_component, name, :start],
+        %{system_time: system_time},
+        metadata,
+        _event_name
+      ) do
+    "live_view"
+    |> @tracer.create_span(nil, start_time: system_time)
+    |> @span.set_name("#{Appsignal.Utils.module_name(metadata[:socket].view)}##{name}")
+    |> @span.set_attribute("appsignal:category", "#{name}.live_view")
+    |> @span.set_sample_data("params", metadata[:params])
+  end
+
   def handle_event_stop(_event, _params, _metadata, _event_name) do
     @tracer.close_span(@tracer.current_span(), end_time: @os.system_time())
   end

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -87,7 +87,7 @@ defmodule Appsignal.Phoenix.LiveView do
   end
 
   def handle_event_start(
-        [:phoenix, :live_view, name, :start],
+        [:phoenix, _type, name, :start],
         %{system_time: system_time},
         metadata,
         _event_name
@@ -99,19 +99,6 @@ defmodule Appsignal.Phoenix.LiveView do
     |> @span.set_attribute("event", metadata[:event])
     |> @span.set_sample_data("params", metadata[:params])
     |> @span.set_sample_data("session_data", metadata[:session])
-  end
-
-  def handle_event_start(
-        [:phoenix, :live_component, name, :start],
-        %{system_time: system_time},
-        metadata,
-        _event_name
-      ) do
-    "live_view"
-    |> @tracer.create_span(nil, start_time: system_time)
-    |> @span.set_name("#{Appsignal.Utils.module_name(metadata[:socket].view)}##{name}")
-    |> @span.set_attribute("appsignal:category", "#{name}.live_view")
-    |> @span.set_sample_data("params", metadata[:params])
   end
 
   def handle_event_stop(_event, _params, _metadata, _event_name) do

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     [
-      {:appsignal, ">= 2.2.15 and < 3.0.0"},
+      {:appsignal, ">= 2.2.16 and < 3.0.0"},
       {:appsignal_plug, ">= 2.0.11 and < 3.0.0"},
       {:phoenix, "~> 1.4"},
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -236,6 +236,21 @@ defmodule Appsignal.Phoenix.LiveViewTest do
           :telemetry.detach(
             {Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :handle_event, :exception]}
           )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_component, :handle_event, :start]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_component, :handle_event, :stop]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_component, :handle_event, :exception]}
+          )
       end)
     end
 


### PR DESCRIPTION
This pull request is a copy of @aj-foster’s work in #47, with a fix to make the tests pass an a patch to remove the separate clause for the live_component type. The latter requires us to depend on :appsignal 2.2.16 or above, as that version includes https://github.com/appsignal/appsignal-elixir/pull/788.