### PR TITLE
Use renamed Appsignal.IntegrationLogger

### DIFF
--- a/.changesets/fix-appsignal-logger-error-on-appsignal-for-elixir-1-4-0.md
+++ b/.changesets/fix-appsignal-logger-error-on-appsignal-for-elixir-1-4-0.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix Appsignal.Logger error on AppSignal for Elixir 1.4.0

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -16,7 +16,7 @@ defmodule Appsignal.Phoenix.EventHandler do
       case :telemetry.attach({__MODULE__, event}, event, fun, :ok) do
         :ok ->
           _ =
-            Appsignal.Logger.debug("Appsignal.Phoenix.EventHandler attached to #{inspect(event)}")
+            Appsignal.IntegrationLogger.debug("Appsignal.Phoenix.EventHandler attached to #{inspect(event)}")
 
           :ok
 

--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -32,7 +32,7 @@ defmodule Appsignal.Phoenix.View do
   """
   defmacro __using__(_) do
     quote do
-      Appsignal.Logger.debug("AppSignal.Phoenix.View attached to #{__MODULE__}")
+      Appsignal.IntegrationLogger.debug("AppSignal.Phoenix.View attached to #{__MODULE__}")
 
       @before_compile Appsignal.Phoenix.View
     end

--- a/mix.exs
+++ b/mix.exs
@@ -67,8 +67,8 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     [
-      {:appsignal, ">= 2.2.16 and < 3.0.0"},
-      {:appsignal_plug, ">= 2.0.11 and < 3.0.0"},
+      {:appsignal, ">= 2.4.0 and < 3.0.0"},
+      {:appsignal_plug, ">= 2.0.12 and < 3.0.0"},
       {:phoenix, "~> 1.4"},
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},
       {:phoenix_live_view, phoenix_live_view_version, optional: true},


### PR DESCRIPTION
Appsignal.Logger was renamed to Appsignal.IntegrationLogger in :appsignal 2.4.0. This patch switches to using
Appsignal.IntegrationLogger and depends on :appsignal 2.4.0 or above.