### PR TITLE
Support Phoenix 1.7's template telemetry

### DIFF
--- a/.changesets/add-template-instrumentation-for-phoenix-1-7.md
+++ b/.changesets/add-template-instrumentation-for-phoenix-1-7.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add automatic template instrumentation for Phoenix 1.7. Phoenix's upcoming release adds telemetry to templates, so using Appsignal.Phoenix.View is no longer needed.

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -9,7 +9,9 @@ defmodule Appsignal.Phoenix.EventHandler do
   def attach do
     handlers = %{
       [:phoenix, :endpoint, :start] => &__MODULE__.phoenix_endpoint_start/4,
-      [:phoenix, :endpoint, :stop] => &__MODULE__.phoenix_endpoint_stop/4
+      [:phoenix, :endpoint, :stop] => &__MODULE__.phoenix_endpoint_stop/4,
+      [:phoenix_template, :render, :start] => &__MODULE__.phoenix_template_render_start/4,
+      [:phoenix_template, :render, :stop] => &__MODULE__.phoenix_template_render_stop/4
     }
 
     for {event, fun} <- handlers do
@@ -47,6 +49,21 @@ defmodule Appsignal.Phoenix.EventHandler do
   end
 
   def phoenix_endpoint_stop(_event, _measurements, _metadata, _config) do
+    @tracer.close_span(@tracer.current_span())
+  end
+
+  def phoenix_template_render_start(_event, _measurements, metadata, _config) do
+    parent = @tracer.current_span()
+
+    "http_request"
+    |> @tracer.create_span(parent)
+    |> @span.set_name(
+      "Render #{inspect(metadata.template)} (#{metadata.type}) template from #{module_name(metadata.view)}"
+    )
+    |> @span.set_attribute("appsignal:category", "render.phoenix_template")
+  end
+
+  def phoenix_template_render_stop(_event, _measurements, _metadata, _config) do
     @tracer.close_span(@tracer.current_span())
   end
 

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -10,8 +10,9 @@ defmodule Appsignal.Phoenix.EventHandler do
     handlers = %{
       [:phoenix, :endpoint, :start] => &__MODULE__.phoenix_endpoint_start/4,
       [:phoenix, :endpoint, :stop] => &__MODULE__.phoenix_endpoint_stop/4,
-      [:phoenix_template, :render, :start] => &__MODULE__.phoenix_template_render_start/4,
-      [:phoenix_template, :render, :stop] => &__MODULE__.phoenix_template_render_stop/4
+      [:phoenix, :controller, :render, :start] => &__MODULE__.phoenix_template_render_start/4,
+      [:phoenix, :controller, :render, :stop] => &__MODULE__.phoenix_template_render_stop/4,
+      [:phoenix, :controller, :render, :exception] => &__MODULE__.phoenix_template_render_stop/4
     }
 
     for {event, fun} <- handlers do

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -34,6 +34,32 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     end
   end
 
+  describe "after receiving an render-start event" do
+    setup [:create_root_span, :render_start_event]
+
+    test "starts a child span", %{span: parent} do
+      assert {:ok, [{"http_request", ^parent}]} = Test.Tracer.get(:create_span)
+    end
+
+    test "sets the span's name" do
+      assert {:ok, [{%Span{}, "Render \"template\" (html) template from PhoenixWeb.View"}]} =
+               Test.Span.get(:set_name)
+    end
+
+    test "sets the span's category" do
+      assert {:ok, [{%Span{}, "appsignal:category", "render.phoenix_template"}]} =
+               Test.Span.get(:set_attribute)
+    end
+  end
+
+  describe "after receiving an render-start and an render-stop event" do
+    setup [:create_root_span, :render_start_event, :render_finish_event]
+
+    test "finishes an event" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
   defp create_root_span(_context) do
     [span: Tracer.create_span("http_request")]
   end
@@ -57,6 +83,22 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
         conn: %Plug.Conn{status: 200},
         options: []
       }
+    )
+  end
+
+  def render_start_event(_context) do
+    :telemetry.execute(
+      [:phoenix_template, :render, :start],
+      %{time: -576_460_736_044_040_000},
+      %{view: PhoenixWeb.View, template: "template", type: "html"}
+    )
+  end
+
+  def render_finish_event(_context) do
+    :telemetry.execute(
+      [:phoenix_template, :render, :stop],
+      %{duration: 49_474_000},
+      %{}
     )
   end
 end

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -60,6 +60,14 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     end
   end
 
+  describe "after receiving an render-start and an render-exception event" do
+    setup [:create_root_span, :render_start_event, :render_exception_event]
+
+    test "finishes an event" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
   defp create_root_span(_context) do
     [span: Tracer.create_span("http_request")]
   end
@@ -88,7 +96,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
 
   def render_start_event(_context) do
     :telemetry.execute(
-      [:phoenix_template, :render, :start],
+      [:phoenix, :controller, :render, :start],
       %{time: -576_460_736_044_040_000},
       %{view: PhoenixWeb.View, template: "template", type: "html"}
     )
@@ -96,7 +104,15 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
 
   def render_finish_event(_context) do
     :telemetry.execute(
-      [:phoenix_template, :render, :stop],
+      [:phoenix, :controller, :render, :stop],
+      %{duration: 49_474_000},
+      %{}
+    )
+  end
+
+  def render_exception_event(_context) do
+    :telemetry.execute(
+      [:phoenix, :controller, :render, :exception],
       %{duration: 49_474_000},
       %{}
     )


### PR DESCRIPTION
Instead of using Appsignal.View, Appsignal.EventHandler subscribes to Phoenix 1.7's new template telemetry to gain template rendering insights.

This works on Phoenix applications running on Phoenix edge (https://github.com/phoenixframework/phoenix/commit/f095d1f82cdf18ffc69226fd59ce36a7fc2ffb44 or newer), meaning you won’t have to use `Appsignal.Phoenix.View` to get templates instrumented on the upcoming AppSignal for Phoenix 2.1.0.