### PR TITLE
Use format instead of type metadata key

### DIFF
--- a/.changesets/fix-metadata-issue-for-template-telemetry.md
+++ b/.changesets/fix-metadata-issue-for-template-telemetry.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix metadata issue for template telemetry

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -59,7 +59,7 @@ defmodule Appsignal.Phoenix.EventHandler do
     "http_request"
     |> @tracer.create_span(parent)
     |> @span.set_name(
-      "Render #{inspect(metadata.template)} (#{metadata.type}) template from #{module_name(metadata.view)}"
+      "Render #{inspect(metadata.template)} (#{metadata.format}) template from #{module_name(metadata.view)}"
     )
     |> @span.set_attribute("appsignal:category", "render.phoenix_template")
   end

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -98,7 +98,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     :telemetry.execute(
       [:phoenix, :controller, :render, :start],
       %{time: -576_460_736_044_040_000},
-      %{view: PhoenixWeb.View, template: "template", type: "html"}
+      %{view: PhoenixWeb.View, template: "template", format: "html"}
     )
   end
 


### PR DESCRIPTION
Instead of :type, the key for the template type in the telemetry metadata is now :format.