### PR TITLE
Use :stacktrace for Phoenix telemetry exceptions

### DIFF
--- a/.changesets/fix-exception-handling-for-unwrapped-phoenix-errors.md
+++ b/.changesets/fix-exception-handling-for-unwrapped-phoenix-errors.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix exception handling for unwrapped Phoenix errors

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -62,7 +62,7 @@ defmodule Appsignal.Phoenix.EventHandler do
   def phoenix_router_dispatch_exception(
         _event,
         _measurements,
-        %{conn: conn, reason: reason, stack: stack},
+        %{conn: conn, reason: reason, stacktrace: stack},
         _config
       ) do
     add_error(@tracer.root_span(), conn, reason, stack)

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -61,7 +61,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
         %{
           conn: conn(),
           reason: %RuntimeError{},
-          stack: [],
+          stacktrace: [],
           options: []
         }
       )


### PR DESCRIPTION
If a Plug.Conn.WrapperError is raised, the wrapped stack trace is included in the :stack key. If the raised exception is not wrapped (which happens when it occurs outside of an action, like when failing to mount a live view), the key is :stacktrace.

Closes #62.