### PR TITLE
Fix deprecation warnings for Elixir 1.15

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -39,7 +39,19 @@ blocks:
             - cache restore dialyzer-plt
             - MIX_ENV=dev mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
-            - MIX_ENV=dev mix dialyzer --format dialyzer
+            - MIX_ENV=dev mix dialyzer --format 
+        - name: Elixir 1.14.5, OTP 25.3, Phoenix ~> 1.7.3
+          commands:
+            - "ERLANG_VERSION=25.3 ELIXIR_VERSION=1.14.5 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
+            - mix test
+        - name: Elixir 1.14.5, OTP 26.0.1, Phoenix ~> 1.7.3
+          commands:
+            - "ERLANG_VERSION=26.0.1 ELIXIR_VERSION=1.14.5 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
+            - mix test
+        - name: Elixir 1.15.0-rc.2, OTP 26.0.1, Phoenix ~> 1.7.3
+          commands:
+            - "ERLANG_VERSION=26.0.1 ELIXIR_VERSION=1.15.0-rc.2 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
+            - mix test
         - name: Elixir 1.14.3, OTP 25.2, Phoenix ~> 1.7.0
           commands:
             - "ERLANG_VERSION=25.2 ELIXIR_VERSION=1.14.3 PHOENIX_VERSION=\"~> 1.7.0\" . bin/setup"
@@ -80,10 +92,6 @@ blocks:
           commands:
             - "ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
             - mix test
-        - name: Elixir 1.10.4, OTP 23.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
         - name: Elixir 1.13.3, OTP 22.3, Phoenix ~> 1.6.0
           commands:
             - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.13.3 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
@@ -96,29 +104,9 @@ blocks:
           commands:
             - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
             - mix test
-        - name: Elixir 1.10.4, OTP 22.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
-        - name: Elixir 1.9.4, OTP 22.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
         - name: Elixir 1.11.4, OTP 21.3, Phoenix ~> 1.6.0
           commands:
             - "ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
-        - name: Elixir 1.10.4, OTP 21.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
-        - name: Elixir 1.9.4, OTP 21.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
-        - name: Elixir 1.9.4, OTP 20.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
             - mix test
       env_vars:
         - name: MIX_ENV

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -48,9 +48,13 @@ blocks:
           commands:
             - "ERLANG_VERSION=26.0.1 ELIXIR_VERSION=1.14.5 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
             - mix test
-        - name: Elixir 1.15.0-rc.2, OTP 26.0.1, Phoenix ~> 1.7.3
+        - name: Elixir 1.15.0-rc.2, OTP 25.3.2.2, Phoenix ~> 1.7.4
           commands:
-            - "ERLANG_VERSION=26.0.1 ELIXIR_VERSION=1.15.0-rc.2 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
+            - "ERLANG_VERSION=25.3.2.2 ELIXIR_VERSION=1.15.0-rc.2 PHOENIX_VERSION=\"~> 1.7.4\" . bin/setup"
+            - mix test
+        - name: Elixir 1.15.0-rc.2, OTP 26.0.1, Phoenix ~> 1.7.4
+          commands:
+            - "ERLANG_VERSION=26.0.1 ELIXIR_VERSION=1.15.0-rc.2 PHOENIX_VERSION=\"~> 1.7.4\" . bin/setup"
             - mix test
         - name: Elixir 1.14.3, OTP 25.2, Phoenix ~> 1.7.0
           commands:

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -27,7 +27,7 @@ defmodule Appsignal.Phoenix.EventHandler do
           :ok
 
         {:error, _} = error ->
-          Logger.warn(
+          Logger.warning(
             "Appsignal.Phoenix.EventHandler not attached to #{inspect(event)}: #{inspect(error)}"
           )
 

--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -78,7 +78,7 @@ defmodule Appsignal.Phoenix.View do
       else
         require Logger
 
-        Logger.warn("""
+        Logger.warning("""
         AppSignal.Phoenix.View NOT attached to #{__MODULE__}
 
         Template rendering instrumentation is now set up automatically, so using

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Appsignal.Phoenix.MixProject do
         licenses: ["MIT"],
         links: %{"GitHub" => "https://github.com/appsignal/appsignal-elixir-phoenix"}
       },
-      elixir: "~> 1.9",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
`Logger.warn` has been replaced by `Logger.warn` since Elixir 1.11 and it's now generating compile warnings with the release of Elixir 1.15.

This PR drops support for Elixir 1.9 and 1.10 in order to move from warn -> warning.
(This might not be the right solution...)

Regardless of the solution, we need to get this fixed ASAP because Elixir 1.15 is going to go live very, very soon.

This is important because anyone using `warnings-as-errors` when compiling builds will start having those builds fail because when you `use Appsignal.Phoenix.View` in your view it will trigger the deprecation warnings.