### PR TITLE
 Use Appsignal.Utils.warning/1 instead of Logger.warn/1

### DIFF
--- a/.changesets/fix-logger-deprecation-warnings-on-elixir-1-15.md
+++ b/.changesets/fix-logger-deprecation-warnings-on-elixir-1-15.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix Logger deprecation warnings on Elixir 1.15

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -39,19 +39,7 @@ blocks:
             - cache restore dialyzer-plt
             - MIX_ENV=dev mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
-            - MIX_ENV=dev mix dialyzer --format 
-        - name: Elixir 1.14.5, OTP 25.3, Phoenix ~> 1.7.3
-          commands:
-            - "ERLANG_VERSION=25.3 ELIXIR_VERSION=1.14.5 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
-            - mix test
-        - name: Elixir 1.14.5, OTP 26.0.1, Phoenix ~> 1.7.3
-          commands:
-            - "ERLANG_VERSION=26.0.1 ELIXIR_VERSION=1.14.5 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
-            - mix test
-        - name: Elixir 1.15.0-rc.2, OTP 26.0.1, Phoenix ~> 1.7.3
-          commands:
-            - "ERLANG_VERSION=26.0.1 ELIXIR_VERSION=1.15.0-rc.2 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
-            - mix test
+            - MIX_ENV=dev mix dialyzer --format dialyzer
         - name: Elixir 1.14.3, OTP 25.2, Phoenix ~> 1.7.0
           commands:
             - "ERLANG_VERSION=25.2 ELIXIR_VERSION=1.14.3 PHOENIX_VERSION=\"~> 1.7.0\" . bin/setup"
@@ -92,6 +80,10 @@ blocks:
           commands:
             - "ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
             - mix test
+        - name: Elixir 1.10.4, OTP 23.3, Phoenix ~> 1.6.0
+          commands:
+            - "ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
+            - mix test
         - name: Elixir 1.13.3, OTP 22.3, Phoenix ~> 1.6.0
           commands:
             - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.13.3 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
@@ -104,9 +96,29 @@ blocks:
           commands:
             - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
             - mix test
+        - name: Elixir 1.10.4, OTP 22.3, Phoenix ~> 1.6.0
+          commands:
+            - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
+            - mix test
+        - name: Elixir 1.9.4, OTP 22.3, Phoenix ~> 1.6.0
+          commands:
+            - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
+            - mix test
         - name: Elixir 1.11.4, OTP 21.3, Phoenix ~> 1.6.0
           commands:
             - "ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
+            - mix test
+        - name: Elixir 1.10.4, OTP 21.3, Phoenix ~> 1.6.0
+          commands:
+            - "ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
+            - mix test
+        - name: Elixir 1.9.4, OTP 21.3, Phoenix ~> 1.6.0
+          commands:
+            - "ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
+            - mix test
+        - name: Elixir 1.9.4, OTP 20.3, Phoenix ~> 1.6.0
+          commands:
+            - "ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
             - mix test
       env_vars:
         - name: MIX_ENV

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -39,7 +39,19 @@ blocks:
             - cache restore dialyzer-plt
             - MIX_ENV=dev mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
-            - MIX_ENV=dev mix dialyzer --format dialyzer
+            - MIX_ENV=dev mix dialyzer --format 
+        - name: Elixir 1.14.5, OTP 25.3, Phoenix ~> 1.7.3
+          commands:
+            - "ERLANG_VERSION=25.3 ELIXIR_VERSION=1.14.5 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
+            - mix test
+        - name: Elixir 1.14.5, OTP 26.0.1, Phoenix ~> 1.7.3
+          commands:
+            - "ERLANG_VERSION=26.0.1 ELIXIR_VERSION=1.14.5 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
+            - mix test
+        - name: Elixir 1.15.0-rc.2, OTP 26.0.1, Phoenix ~> 1.7.3
+          commands:
+            - "ERLANG_VERSION=26.0.1 ELIXIR_VERSION=1.15.0-rc.2 PHOENIX_VERSION=\"~> 1.7.3\" . bin/setup"
+            - mix test
         - name: Elixir 1.14.3, OTP 25.2, Phoenix ~> 1.7.0
           commands:
             - "ERLANG_VERSION=25.2 ELIXIR_VERSION=1.14.3 PHOENIX_VERSION=\"~> 1.7.0\" . bin/setup"
@@ -80,10 +92,6 @@ blocks:
           commands:
             - "ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
             - mix test
-        - name: Elixir 1.10.4, OTP 23.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
         - name: Elixir 1.13.3, OTP 22.3, Phoenix ~> 1.6.0
           commands:
             - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.13.3 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
@@ -96,29 +104,9 @@ blocks:
           commands:
             - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
             - mix test
-        - name: Elixir 1.10.4, OTP 22.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
-        - name: Elixir 1.9.4, OTP 22.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
         - name: Elixir 1.11.4, OTP 21.3, Phoenix ~> 1.6.0
           commands:
             - "ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
-        - name: Elixir 1.10.4, OTP 21.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
-        - name: Elixir 1.9.4, OTP 21.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
-            - mix test
-        - name: Elixir 1.9.4, OTP 20.3, Phoenix ~> 1.6.0
-          commands:
-            - "ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 PHOENIX_VERSION=\"~> 1.6.0\" . bin/setup"
             - mix test
       env_vars:
         - name: MIX_ENV

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -27,7 +27,7 @@ defmodule Appsignal.Phoenix.EventHandler do
           :ok
 
         {:error, _} = error ->
-          Logger.warn(
+          Logger.warning(
             "Appsignal.Phoenix.EventHandler not attached to #{inspect(event)}: #{inspect(error)}"
           )
 

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -4,8 +4,6 @@ defmodule Appsignal.Phoenix.EventHandler do
   @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
   @moduledoc false
 
-  require Logger
-
   def attach do
     handlers = %{
       [:phoenix, :router_dispatch, :start] => &__MODULE__.phoenix_router_dispatch_start/4,
@@ -27,7 +25,7 @@ defmodule Appsignal.Phoenix.EventHandler do
           :ok
 
         {:error, _} = error ->
-          Logger.warning(
+          Appsignal.Utils.warning(
             "Appsignal.Phoenix.EventHandler not attached to #{inspect(event)}: #{inspect(error)}"
           )
 

--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -78,7 +78,7 @@ defmodule Appsignal.Phoenix.View do
       else
         require Logger
 
-        Logger.warn("""
+        Logger.warning("""
         AppSignal.Phoenix.View NOT attached to #{__MODULE__}
 
         Template rendering instrumentation is now set up automatically, so using

--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -76,9 +76,7 @@ defmodule Appsignal.Phoenix.View do
           fun.()
         end
       else
-        require Logger
-
-        Logger.warning("""
+        Appsignal.Utils.warning("""
         AppSignal.Phoenix.View NOT attached to #{__MODULE__}
 
         Template rendering instrumentation is now set up automatically, so using

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Appsignal.Phoenix.MixProject do
         licenses: ["MIT"],
         links: %{"GitHub" => "https://github.com/appsignal/appsignal-elixir-phoenix"}
       },
-      elixir: "~> 1.9",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Appsignal.Phoenix.MixProject do
         licenses: ["MIT"],
         links: %{"GitHub" => "https://github.com/appsignal/appsignal-elixir-phoenix"}
       },
-      elixir: "~> 1.11",
+      elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
@@ -64,7 +64,7 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     [
-      {:appsignal, ">= 2.5.1 and < 3.0.0"},
+      {:appsignal, ">= 2.7.4 and < 3.0.0"},
       {:appsignal_plug, ">= 2.0.13 and < 3.0.0"},
       {:phoenix, System.get_env("PHOENIX_VERSION", "~> 1.4")},
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule Appsignal.Phoenix.MixProject do
 
     [
       {:appsignal, ">= 2.7.4 and < 3.0.0"},
-      {:appsignal_plug, ">= 2.0.13 and < 3.0.0"},
+      {:appsignal_plug, ">= 2.0.14 and < 3.0.0"},
       {:phoenix, System.get_env("PHOENIX_VERSION", "~> 1.4")},
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},
       {:phoenix_live_view, phoenix_live_view_version, optional: true},


### PR DESCRIPTION
Update the minimal version of the appsignal dependency to 2.7.4, which is the version that introduces the backwards compatible logging functions in `Appsignal.Utils`. Then, use `Appsignal.Utils.warning/1` in `Appsignal.Phoenix.View` and `Appsignal.Phoenix.EventHandler` to support Elixir 1.10 through 1.15.

Closes #69.