### PR TITLE
Use `set_sample_data_if_nil` on span close

### DIFF
--- a/.changesets/fix-sample-data-being-overriden-by-phoenix-data.md
+++ b/.changesets/fix-sample-data-being-overriden-by-phoenix-data.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix an issue in which sample data is overriden by Phoenix data when the span closes.

--- a/lib/appsignal_phoenix/channel.ex
+++ b/lib/appsignal_phoenix/channel.ex
@@ -50,8 +50,8 @@ defmodule Appsignal.Phoenix.Channel do
 
             _ =
               span
-              |> @span.set_sample_data("params", params)
-              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+              |> @span.set_sample_data_if_nil("params", params)
+              |> @span.set_sample_data_if_nil("environment", Appsignal.Metadata.metadata(socket))
               |> @span.add_error(kind, reason, stack)
               |> @tracer.close_span()
 
@@ -61,8 +61,8 @@ defmodule Appsignal.Phoenix.Channel do
           result ->
             _ =
               span
-              |> @span.set_sample_data("params", params)
-              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+              |> @span.set_sample_data_if_nil("params", params)
+              |> @span.set_sample_data_if_nil("environment", Appsignal.Metadata.metadata(socket))
 
             result
         end

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -93,9 +93,9 @@ defmodule Appsignal.Phoenix.EventHandler do
   defp set_span_data(span, %{conn: conn} = metadata) do
     span
     |> @span.set_name(name(metadata))
-    |> @span.set_sample_data("params", Appsignal.Metadata.params(conn))
-    |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(conn))
-    |> @span.set_sample_data("session_data", Appsignal.Metadata.session(conn))
+    |> @span.set_sample_data_if_nil("params", Appsignal.Metadata.params(conn))
+    |> @span.set_sample_data_if_nil("environment", Appsignal.Metadata.metadata(conn))
+    |> @span.set_sample_data_if_nil("session_data", Appsignal.Metadata.session(conn))
   end
 
   defp name(%{conn: conn} = metadata) do

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -22,8 +22,8 @@ defmodule Appsignal.Phoenix.LiveView do
 
             _ =
               span
-              |> @span.set_sample_data("params", params)
-              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+              |> @span.set_sample_data_if_nil("params", params)
+              |> @span.set_sample_data_if_nil("environment", Appsignal.Metadata.metadata(socket))
               |> @span.add_error(kind, reason, stack)
               |> @tracer.close_span()
 
@@ -33,8 +33,8 @@ defmodule Appsignal.Phoenix.LiveView do
           result ->
             _ =
               span
-              |> @span.set_sample_data("params", params)
-              |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(socket))
+              |> @span.set_sample_data_if_nil("params", params)
+              |> @span.set_sample_data_if_nil("environment", Appsignal.Metadata.metadata(socket))
 
             result
         end

--- a/mix.exs
+++ b/mix.exs
@@ -64,8 +64,8 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     [
-      {:appsignal, ">= 2.7.4 and < 3.0.0"},
-      {:appsignal_plug, ">= 2.0.14 and < 3.0.0"},
+      {:appsignal, ">= 2.7.6 and < 3.0.0"},
+      {:appsignal_plug, ">= 2.0.15 and < 3.0.0"},
       {:phoenix, System.get_env("PHOENIX_VERSION", "~> 1.4")},
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},
       {:phoenix_live_view, phoenix_live_view_version, optional: true},

--- a/test/appsignal_phoenix/channel_test.exs
+++ b/test/appsignal_phoenix/channel_test.exs
@@ -155,7 +155,7 @@ defmodule Appsignal.Phoenix.ChannelTest do
   end
 
   defp assert_sample_data(asserted_key, asserted_data) do
-    {:ok, sample_data} = Test.Span.get(:set_sample_data)
+    {:ok, sample_data} = Test.Span.get(:set_sample_data_if_nil)
 
     assert Enum.any?(sample_data, fn {%Span{}, key, data} ->
              key == asserted_key and data == asserted_data

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -40,7 +40,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     end
 
     test "sets the root span's parameters" do
-      {:ok, calls} = Test.Span.get(:set_sample_data)
+      {:ok, calls} = Test.Span.get(:set_sample_data_if_nil)
 
       [{%Span{}, "params", params}] =
         Enum.filter(calls, fn {_span, key, _value} -> key == "params" end)
@@ -49,7 +49,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     end
 
     test "sets the root span's sample data" do
-      {:ok, calls} = Test.Span.get(:set_sample_data)
+      {:ok, calls} = Test.Span.get(:set_sample_data_if_nil)
 
       [{%Span{}, "environment", environment}] =
         Enum.filter(calls, fn {_span, key, _value} -> key == "environment" end)
@@ -111,7 +111,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     end
 
     test "sets the root span's sample data" do
-      {:ok, calls} = Test.Span.get(:set_sample_data)
+      {:ok, calls} = Test.Span.get(:set_sample_data_if_nil)
 
       [{%Span{}, "environment", environment}] =
         Enum.filter(calls, fn {_span, key, _value} -> key == "environment" end)

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -495,7 +495,7 @@ defmodule Appsignal.Phoenix.LiveViewTest do
   end
 
   defp assert_sample_data(asserted_key, asserted_data) do
-    {:ok, sample_data} = Test.Span.get(:set_sample_data)
+    {:ok, sample_data} = Test.Span.get(:set_sample_data_if_nil)
 
     assert Enum.any?(sample_data, fn {%Span{}, key, data} ->
              key == asserted_key and data == asserted_data


### PR DESCRIPTION
Part of https://github.com/appsignal/appsignal-elixir/issues/862.

Before merging this, the version bounds for the `appsignal` and `appsignal-plug` dependencies need to be updated to a version where `set_sample_data_if_nil` is implemented. This requires a release that contains the changes in https://github.com/appsignal/appsignal-elixir/pull/866 and https://github.com/appsignal/appsignal-elixir-plug/pull/37.

The tests are not passing on CI because they are ran against the latest release of the Elixir and Plug integrations, which do not have the `set_sample_data_if_nil` function. They should pass after updating the version bounds as described above.

---

When closing spans, use `set_sample_data_if_nil` instead of `set_sample_data` as to not override custom instrumentation set by the user while the span was open.