### PR TITLE
Lock Dialyxir to 1.3 for older Elixir versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Appsignal.Phoenix.MixProject do
       {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},
       {:phoenix_live_view, phoenix_live_view_version, optional: true},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
-      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
       {:poison, "~> 5.0", only: [:dev, :test], runtime: false},
       {:telemetry, telemetry_version}


### PR DESCRIPTION
Newer versions of Dialyxir use the
[Kernel.then/2](https://hexdocs.pm/elixir/Kernel.html#then/2) syntax introduced in Elixir 1.12.

Lock the package to 1.3, so we can run it on older versions while we still support them.

Related PR in appsignal-elixir repo:
https://github.com/appsignal/appsignal-elixir/pull/882

See also https://github.com/appsignal/appsignal-elixir/issues/881 for dropping those older versions.

[skip changeset]
[skip review]