### PR TITLE
Fix build by locking Hackney on OTP < 21

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,12 @@ defmodule Appsignal.Phoenix.MixProject do
     system_version = System.version()
     otp_version = System.otp_release()
 
+    hackney_version =
+      case otp_version >= "21" do
+        true -> "~> 1.6"
+        false -> "1.18.1"
+      end
+
     mime_and_plug_dependencies =
       if Mix.env() == :test || Mix.env() == :test_no_nif do
         case Version.compare(system_version, "1.10.0") do
@@ -73,7 +79,8 @@ defmodule Appsignal.Phoenix.MixProject do
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
       {:poison, "~> 5.0", only: [:dev, :test], runtime: false},
-      {:telemetry, telemetry_version}
+      {:telemetry, telemetry_version},
+      {:hackney, hackney_version}
     ] ++ mime_and_plug_dependencies
   end
 end


### PR DESCRIPTION
It fails to build the `parse_trans` package on OTP < 21, because Hackney bumped its version lock between package version 1.18.1 and 1.18.2. The newer `parse_trans` version requires OTP > 21.

[skip changeset]
[skip review]