### PR TITLE
Fix warnings generated on elixir 1.16

### DIFF
--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -52,7 +52,7 @@ defmodule Appsignal.Phoenix.View do
           {root, _pattern, _names} = __templates__()
           path = Path.join(root, template)
 
-          do_render(@tracer.current_span, path, fn ->
+          do_render(@tracer.current_span(), path, fn ->
             super(template, assigns)
           end)
         end


### PR DESCRIPTION
Each view generates warnings like this
```
[Warn  - 20:02:23]     warning: parentheses are required for function calls with no arguments, got: @tracer.current_span
    │
  1 │ defmodule My.Web.ErrorView do
    │ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/my/views/error_view.ex:1
```