### PR TITLE
Optional fun argument for attach

### DIFF
--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -50,7 +50,7 @@ defmodule Appsignal.Phoenix.LiveView do
     instrument(module, name, params, socket, function)
   end
 
-  def attach do
+  def attach(fun \\ nil) do
     [
       [:phoenix, :live_view, :mount],
       [:phoenix, :live_view, :handle_params],
@@ -65,7 +65,7 @@ defmodule Appsignal.Phoenix.LiveView do
           {__MODULE__, event ++ [:start]},
           event ++ [:start],
           &__MODULE__.handle_event_start/4,
-          name
+          {name, fun}
         )
 
       _ =
@@ -90,11 +90,12 @@ defmodule Appsignal.Phoenix.LiveView do
         [:phoenix, _type, name, :start],
         %{system_time: system_time},
         metadata,
-        _event_name
+        {_event_name, fun}
       ) do
     "live_view"
     |> @tracer.create_span(nil, start_time: system_time)
     |> @span.set_name("#{Appsignal.Utils.module_name(metadata[:socket].view)}##{name}")
+    |> execute_fun(fun)
     |> @span.set_attribute("appsignal:category", "#{name}.live_view")
     |> @span.set_attribute("event", metadata[:event])
     |> @span.set_sample_data("params", metadata[:params])
@@ -112,4 +113,7 @@ defmodule Appsignal.Phoenix.LiveView do
 
     @tracer.ignore()
   end
+
+  def execute_fun(nil, _fun), do: nil
+  def execute_fun(span, fun), do: fun.(span)
 end

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -114,6 +114,6 @@ defmodule Appsignal.Phoenix.LiveView do
     @tracer.ignore()
   end
 
-  def execute_fun(nil, _fun), do: nil
-  def execute_fun(span, fun), do: fun.(span)
+  defp execute_fun(span, fun) when is_function(fun), do: fun.(span)
+  defp execute_fun(span, _), do: span
 end

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -270,6 +270,89 @@ defmodule Appsignal.Phoenix.LiveViewTest do
     end
   end
 
+  describe "attach/1" do
+    setup do
+      fun = fn span ->
+        Span.set_sample_data(span, "custom_data", %{custom: "data"})
+      end
+
+      Appsignal.Phoenix.LiveView.attach(fun)
+
+      on_exit(fn ->
+        :ok =
+          :telemetry.detach({Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :mount, :start]})
+
+        :ok =
+          :telemetry.detach({Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :mount, :stop]})
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :mount, :exception]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :handle_params, :start]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :handle_params, :stop]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :handle_params, :exception]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :handle_event, :start]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :handle_event, :stop]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :handle_event, :exception]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_component, :handle_event, :start]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_component, :handle_event, :stop]}
+          )
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_component, :handle_event, :exception]}
+          )
+      end)
+    end
+
+    test "attach/1 attaches to LiveView events" do
+      assert attached?([:phoenix, :live_view, :mount, :start])
+      assert attached?([:phoenix, :live_view, :mount, :stop])
+      assert attached?([:phoenix, :live_view, :mount, :exception])
+      assert attached?([:phoenix, :live_view, :handle_params, :start])
+      assert attached?([:phoenix, :live_view, :handle_params, :stop])
+      assert attached?([:phoenix, :live_view, :handle_params, :exception])
+      assert attached?([:phoenix, :live_view, :handle_event, :start])
+      assert attached?([:phoenix, :live_view, :handle_event, :stop])
+      assert attached?([:phoenix, :live_view, :handle_event, :exception])
+      assert attached?([:phoenix, :live_component, :handle_event, :start])
+      assert attached?([:phoenix, :live_component, :handle_event, :stop])
+      assert attached?([:phoenix, :live_component, :handle_event, :exception])
+    end
+  end
+
   describe "handle_event_start/4, with a mount event" do
     setup do
       event = [:phoenix, :live_view, :mount, :start]

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -361,7 +361,7 @@ defmodule Appsignal.Phoenix.LiveViewTest do
         {__MODULE__, event},
         event,
         &Appsignal.Phoenix.LiveView.handle_event_start/4,
-        :ok
+        {:ok, nil}
       )
 
       :telemetry.execute(
@@ -417,7 +417,7 @@ defmodule Appsignal.Phoenix.LiveViewTest do
         {__MODULE__, event},
         event,
         &Appsignal.Phoenix.LiveView.handle_event_start/4,
-        :ok
+        {:ok, nil}
       )
 
       :telemetry.execute(
@@ -474,7 +474,7 @@ defmodule Appsignal.Phoenix.LiveViewTest do
         {__MODULE__, event},
         event,
         &Appsignal.Phoenix.LiveView.handle_event_start/4,
-        :ok
+        {:ok, nil}
       )
 
       :telemetry.execute(


### PR DESCRIPTION
This change allows a fun to be given to `attach` that can be executed in the `handle_event_start`. This can be used to set custom data in runtime.

For example, this allows us to take a different OpenTelementry span of HoneyComb and add custom_data with a link to HoneyComb. With this we can do the following:
```ex 
  Appsignal.Phoenix.LiveView.attach(add_honeycomb_link())


  def add_honeycomb_link do
    fn span ->
      Appsignal.Span.set_sample_data(span, "custom_data", %{"HoneyComb trace": honeycomb_link()})
    end
  end
 ```
