### PR TITLE
Allow phoenix_html 4.0 as a dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -73,7 +73,7 @@ defmodule Appsignal.Phoenix.MixProject do
       {:appsignal, ">= 2.7.6 and < 3.0.0"},
       {:appsignal_plug, ">= 2.0.15 and < 3.0.0"},
       {:phoenix, System.get_env("PHOENIX_VERSION", "~> 1.4")},
-      {:phoenix_html, "~> 2.11 or ~> 3.0", optional: true},
+      {:phoenix_html, "~> 2.11 or ~> 3.0 or ~> 4.0", optional: true},
       {:phoenix_live_view, phoenix_live_view_version, optional: true},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
I am not sure where Phoenix.HTML gets used, but seems like its only a dependency to ensure the test still works. 

Updating this allows us to upgrade phoenix_html to 4.0 in phoenix apps using this package. 