### PR TITLE
Attach to [:phoenix, :live_view, :render]

### DIFF
--- a/.changesets/handle-live-view-render-messages.md
+++ b/.changesets/handle-live-view-render-messages.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Handle live_view :render messages received through :telemetry.

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -55,6 +55,7 @@ defmodule Appsignal.Phoenix.LiveView do
       [:phoenix, :live_view, :mount],
       [:phoenix, :live_view, :handle_params],
       [:phoenix, :live_view, :handle_event],
+      [:phoenix, :live_view, :render],
       [:phoenix, :live_component, :handle_event]
     ]
     |> Enum.each(fn event ->

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -238,6 +238,17 @@ defmodule Appsignal.Phoenix.LiveViewTest do
           )
 
         :ok =
+          :telemetry.detach({Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :render, :start]})
+
+        :ok =
+          :telemetry.detach({Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :render, :stop]})
+
+        :ok =
+          :telemetry.detach(
+            {Appsignal.Phoenix.LiveView, [:phoenix, :live_view, :render, :exception]}
+          )
+
+        :ok =
           :telemetry.detach(
             {Appsignal.Phoenix.LiveView, [:phoenix, :live_component, :handle_event, :start]}
           )
@@ -264,6 +275,9 @@ defmodule Appsignal.Phoenix.LiveViewTest do
       assert attached?([:phoenix, :live_view, :handle_event, :start])
       assert attached?([:phoenix, :live_view, :handle_event, :stop])
       assert attached?([:phoenix, :live_view, :handle_event, :exception])
+      assert attached?([:phoenix, :live_view, :render, :start])
+      assert attached?([:phoenix, :live_view, :render, :stop])
+      assert attached?([:phoenix, :live_view, :render, :exception])
       assert attached?([:phoenix, :live_component, :handle_event, :start])
       assert attached?([:phoenix, :live_component, :handle_event, :stop])
       assert attached?([:phoenix, :live_component, :handle_event, :exception])


### PR DESCRIPTION
Aside from :mount, :handle_params, and :handle_event, attach to
:render in the LiveView integration.

With this patch, the LiveView integration hooks into all LiveView
telemetry
events (https://hexdocs.pm/phoenix_live_view/telemetry.html).

Fixes https://github.com/appsignal/feature-requests/issues/325