### PR TITLE
Determine action name from ActionClauseErrors

### DIFF
--- a/.changesets/set-action-name-for-phoenix-actionclauseerror-errors.md
+++ b/.changesets/set-action-name-for-phoenix-actionclauseerror-errors.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Set an action name for Phoenix.ActionClauseError errors. It will now group these errors per controller-action combination for more convenient grouping.

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -66,7 +66,20 @@ defmodule Appsignal.Phoenix.EventHandler do
     add_error(@tracer.root_span(), conn, reason, stack)
   end
 
-  defp add_error(span, conn, reason, stack) do
+  defp add_error(
+         span,
+         conn,
+         %Phoenix.ActionClauseError{module: module, function: function} = reason,
+         stack
+       ) do
+    span
+    |> @span.set_name("#{reason.module}##{reason.function}")
+    |> do_add_error(conn, reason, stack)
+  end
+
+  defp add_error(span, conn, reason, stack), do: do_add_error(span, conn, reason, stack)
+
+  defp do_add_error(span, conn, reason, stack) do
     span
     |> @span.add_error(:error, reason, stack)
     |> set_span_data(%{conn: conn})


### PR DESCRIPTION
When a Phoenix.ActionClauseError is detected, it will not be able to set the controller and action name as the span (action) name. The connection doesn't have the controller action on its object because there's a function signature mismatch.

The controller action it expects to find can be fetched from the error object. That's what this change does specifically for the Phoenix.ActionClauseError.

- [Related support thread](https://app.intercom.com/a/inbox/yzor8gyw/inbox/shared/unassigned/conversation/16410700311290?view=List)
- [Related internal conversation](https://appsignal.slack.com/archives/CNPP953E2/p1713966958577269)