### PR TITLE
Allow custom action names to be set

### DIFF
--- a/.changesets/allow-custom-action-names.md
+++ b/.changesets/allow-custom-action-names.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+type: change
+---
+
+Allow custom action names to be set in Phoenix routes. For example, in a plug middleware or the controller:
+
+```elixir
+Appsignal.Tracer.root_span()
+|> Appsignal.Span.set_name("CustomActionName")
+```

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -73,7 +73,7 @@ defmodule Appsignal.Phoenix.EventHandler do
          stack
        ) do
     span
-    |> @span.set_name("#{module}##{function}")
+    |> @span.set_name_if_nil("#{module}##{function}")
     |> do_add_error(conn, reason, stack)
   end
 
@@ -105,7 +105,7 @@ defmodule Appsignal.Phoenix.EventHandler do
 
   defp set_span_data(span, %{conn: conn} = metadata) do
     span
-    |> @span.set_name(name(metadata))
+    |> @span.set_name_if_nil(name(metadata))
     |> @span.set_sample_data_if_nil("params", Appsignal.Metadata.params(conn))
     |> @span.set_sample_data_if_nil("environment", Appsignal.Metadata.metadata(conn))
     |> @span.set_sample_data_if_nil("session_data", Appsignal.Metadata.session(conn))

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     [
-      {:appsignal, ">= 2.7.6 and < 3.0.0"},
+      {:appsignal, ">= 2.11.0 and < 3.0.0"},
       {:appsignal_plug, ">= 2.0.15 and < 3.0.0"},
       {:phoenix, System.get_env("PHOENIX_VERSION", "~> 1.4")},
       {:phoenix_html, "~> 2.11 or ~> 3.0 or ~> 4.0", optional: true},

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -27,7 +27,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
 
     test "sets the span's name" do
       assert {:ok, [{%Span{}, "AppsignalPhoenixExampleWeb.PageController#index"}]} =
-               Test.Span.get(:set_name)
+               Test.Span.get(:set_name_if_nil)
     end
 
     test "sets the root span's category" do
@@ -77,7 +77,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "GET /foo/:bar"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "GET /foo/:bar"}]} = Test.Span.get(:set_name_if_nil)
     end
   end
 
@@ -99,7 +99,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
 
     test "sets the root span's name" do
       assert {:ok, [{%Span{}, "AppsignalPhoenixExampleWeb.PageController#index"}]} =
-               Test.Span.get(:set_name)
+               Test.Span.get(:set_name_if_nil)
     end
 
     test "sets the root span's error" do
@@ -147,7 +147,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
 
     test "sets the root span's name" do
       assert {:ok, [{%Span{}, "AppsignalPhoenixExampleWeb.PageController#index"}]} =
-               Test.Span.get(:set_name)
+               Test.Span.get(:set_name_if_nil)
     end
 
     test "sets the root span's error" do
@@ -182,7 +182,7 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
                 {%Span{}, nil},
                 {%Span{}, "Elixir.MyModule#my_function"}
               ]} =
-               Test.Span.get(:set_name)
+               Test.Span.get(:set_name_if_nil)
     end
 
     test "sets the root span's error" do


### PR DESCRIPTION
Set the Phoenix action name using `Span.set_name_if_nil` so we don't overwrite any custom set action names, or those set by other integrations, like our Absinthe one in https://github.com/appsignal/appsignal-elixir/pull/945