### PR TITLE
Don't use Appsignal.Utils for logging & compiling

### DIFF
--- a/lib/appsignal_phoenix/channel.ex
+++ b/lib/appsignal_phoenix/channel.ex
@@ -28,9 +28,8 @@ defmodule Appsignal.Phoenix.Channel do
 
   """
 
-  require Appsignal.Utils
-  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   def instrument(module, name, socket, fun) do
     instrument(module, name, %{}, socket, fun)

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -1,8 +1,9 @@
 defmodule Appsignal.Phoenix.EventHandler do
-  require Appsignal.Utils
-  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
   @moduledoc false
+
+  require Logger
 
   def attach do
     handlers = %{
@@ -27,7 +28,7 @@ defmodule Appsignal.Phoenix.EventHandler do
           :ok
 
         {:error, _} = error ->
-          Appsignal.Utils.warning(
+          Logger.warning(
             "Appsignal.Phoenix.EventHandler not attached to #{inspect(event)}: #{inspect(error)}"
           )
 

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -1,8 +1,7 @@
 defmodule Appsignal.Phoenix.LiveView do
-  require Appsignal.Utils
-  @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
-  @os Appsignal.Utils.compile_env(:appsignal_plug, :os, :os)
+  @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @os Application.compile_env(:appsignal_plug, :os, :os)
 
   def instrument(module, name, socket, fun) do
     instrument(module, name, %{}, socket, fun)

--- a/lib/appsignal_phoenix/template.ex
+++ b/lib/appsignal_phoenix/template.ex
@@ -1,6 +1,5 @@
 defmodule Appsignal.Phoenix.Template do
-  require Appsignal.Utils
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
   @moduledoc false
 
   def compile(fun, path) do

--- a/lib/appsignal_phoenix/view.ex
+++ b/lib/appsignal_phoenix/view.ex
@@ -42,9 +42,8 @@ defmodule Appsignal.Phoenix.View do
     quote do
       if Module.defines?(__MODULE__, {:__templates__, 0}) &&
            Module.defines?(__MODULE__, {:render, 2}) do
-        require Appsignal.Utils
-        @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
-        @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+        @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+        @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
 
         defoverridable render: 2
 
@@ -76,7 +75,7 @@ defmodule Appsignal.Phoenix.View do
           fun.()
         end
       else
-        Appsignal.Utils.warning("""
+        Logger.warning("""
         AppSignal.Phoenix.View NOT attached to #{__MODULE__}
 
         Template rendering instrumentation is now set up automatically, so using


### PR DESCRIPTION
Appsignal.Utils exposes warning/1 and compile_env/1 functions, which are wrappers to allow for using older Elixir versions. Because we're dropping any Elixir version under 1.11, these are no longer needed.

[skip changeset]