### PR TITLE
Drop OTP <24 & Elixir <1.11 dep version exceptions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,6 @@ defmodule Appsignal.Phoenix.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     system_version = System.version()
-    otp_version = System.otp_release()
 
     mime_and_plug_dependencies =
       if Mix.env() == :test || Mix.env() == :test_no_nif do
@@ -54,12 +53,6 @@ defmodule Appsignal.Phoenix.MixProject do
       case Version.compare(system_version, "1.12.0") do
         :lt -> ">= 0.9.0 and < 0.18.0"
         _ -> "~> 0.9"
-      end
-
-    telemetry_version =
-      case otp_version < "21" do
-        true -> "~> 0.4"
-        false -> "~> 0.4 or ~> 1.0"
       end
 
     credo_version =
@@ -78,7 +71,7 @@ defmodule Appsignal.Phoenix.MixProject do
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:credo, credo_version, only: [:dev, :test], runtime: false},
       {:poison, "~> 5.0", only: [:dev, :test], runtime: false},
-      {:telemetry, telemetry_version},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:hackney, "~> 1.6"}
     ] ++ mime_and_plug_dependencies
   end

--- a/mix.exs
+++ b/mix.exs
@@ -40,12 +40,6 @@ defmodule Appsignal.Phoenix.MixProject do
     system_version = System.version()
     otp_version = System.otp_release()
 
-    hackney_version =
-      case otp_version >= "21" do
-        true -> "~> 1.6"
-        false -> "1.18.1"
-      end
-
     mime_and_plug_dependencies =
       if Mix.env() == :test || Mix.env() == :test_no_nif do
         case Version.compare(system_version, "1.10.0") do
@@ -85,7 +79,7 @@ defmodule Appsignal.Phoenix.MixProject do
       {:credo, credo_version, only: [:dev, :test], runtime: false},
       {:poison, "~> 5.0", only: [:dev, :test], runtime: false},
       {:telemetry, telemetry_version},
-      {:hackney, hackney_version}
+      {:hackney, "~> 1.6"}
     ] ++ mime_and_plug_dependencies
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -39,16 +39,6 @@ defmodule Appsignal.Phoenix.MixProject do
   defp deps do
     system_version = System.version()
 
-    mime_and_plug_dependencies =
-      if Mix.env() == :test || Mix.env() == :test_no_nif do
-        case Version.compare(system_version, "1.10.0") do
-          :lt -> [{:plug, "~> 1.13.0"}, {:mime, "~> 1.0"}]
-          _ -> []
-        end
-      else
-        []
-      end
-
     phoenix_live_view_version =
       case Version.compare(system_version, "1.12.0") do
         :lt -> ">= 0.9.0 and < 0.18.0"
@@ -73,6 +63,6 @@ defmodule Appsignal.Phoenix.MixProject do
       {:poison, "~> 5.0", only: [:dev, :test], runtime: false},
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:hackney, "~> 1.6"}
-    ] ++ mime_and_plug_dependencies
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -57,10 +57,9 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     phoenix_live_view_version =
-      case {otp_version < "21", Version.compare(system_version, "1.12.0")} do
-        {true, _} -> ">= 0.9.0 and < 0.17.4"
-        {_, :lt} -> ">= 0.9.0 and < 0.18.0"
-        {_, _} -> "~> 0.9"
+      case Version.compare(system_version, "1.12.0") do
+        :lt -> ">= 0.9.0 and < 0.18.0"
+        _ -> "~> 0.9"
       end
 
     telemetry_version =


### PR DESCRIPTION
Over the years, we've added version exceptions to the Appsignal for Phoenix dependencies in order for them to run on older versions of OTP and Elixir. Now, since dropping OTP 23 and lower and Elixir 1.10 and lower from CI, some of these can be safely removed.

[skip changeset]