### PR TITLE
Allow using LiveView 1.0 and up

### DIFF
--- a/.changesets/add-liveview-1-x-to-allowed-versions-in-dependencies.md
+++ b/.changesets/add-liveview-1-x-to-allowed-versions-in-dependencies.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add LiveView 1.x in the allowed list of versions in the dependencies.

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Appsignal.Phoenix.MixProject do
     phoenix_live_view_version =
       case Version.compare(system_version, "1.12.0") do
         :lt -> ">= 0.9.0 and < 0.18.0"
-        _ -> "~> 0.9"
+        _ -> "~> 0.9 or ~> 1.0"
       end
 
     credo_version =


### PR DESCRIPTION
After verifying that the live view support works on the most recent release candidate, add ~> 1.0 to the version range for the live view dependency.

Closes #91.