### PR TITLE
Set metadata from :router_dispatch stop events

### DIFF
--- a/.changesets/set-request-metadata-in-router_dispatch-events.md
+++ b/.changesets/set-request-metadata-in-router_dispatch-events.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Set request metadata in :router_dispatch events to support Phoenix apps that don't fire :endpoint events.

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -38,59 +38,32 @@ defmodule Appsignal.Phoenix.EventHandler do
   end
 
   def phoenix_endpoint_start(_event, _measurements, _metadata, _config) do
-    parent_span = @tracer.current_span()
+    parent = @tracer.current_span()
 
-    span = "http_request"
-    |> @tracer.create_span(parent_span)
+    "http_request"
+    |> @tracer.create_span(parent)
     |> @span.set_attribute("appsignal:category", "call.phoenix_endpoint")
-
-    Logger.debug(fn -> """
-    AppSignal.Phoenix.EventHandler received [:phoenix, :endpoint, :start]:
-      root_span: #{inspect(@tracer.root_span())}
-      parent_span: #{inspect(parent_span)}
-      span: #{inspect(span)}
-    """ end)
   end
 
   def phoenix_endpoint_stop(_event, _measurements, metadata, _config) do
-    root_span = set_span_data(@tracer.root_span(), metadata)
-    span = @tracer.current_span()
+    _root_span = set_span_data(@tracer.root_span(), metadata)
 
-    Logger.debug(fn -> """
-    AppSignal.Phoenix.EventHandler received [:phoenix, :endpoint, :stop]:
-      root_span: #{inspect(root_span)}
-      span: #{inspect(span)}
-    """ end)
-
-    @tracer.close_span(span)
+    @tracer.current_span()
+    |> @tracer.close_span()
   end
 
   def phoenix_router_dispatch_start(_event, _measurements, _metadata, _config) do
-    parent_span = @tracer.current_span()
+    parent = @tracer.current_span()
 
-    span = "http_request"
-    |> @tracer.create_span(parent_span)
+    "http_request"
+    |> @tracer.create_span(parent)
     |> @span.set_attribute("appsignal:category", "call.phoenix_router_dispatch")
-
-    Logger.debug(fn -> """
-    AppSignal.Phoenix.EventHandler received [:phoenix, :router_dispatch, :start]:
-      root_span: #{inspect(@tracer.root_span())}
-      parent_span: #{inspect(parent_span)}
-      span: #{inspect(span)}
-    """ end)
   end
 
   def phoenix_router_dispatch_stop(_event, _measurements, metadata, _config) do
     _root_span = set_span_data(@tracer.root_span(), metadata)
-    span = @tracer.current_span()
 
-    Logger.debug(fn -> """
-    AppSignal.Phoenix.EventHandler received [:phoenix, :router_dispatch, :stop]:
-      root_span: #{inspect(root_span)}
-      span: #{inspect(span)}
-    """ end)
-
-    @tracer.close_span(span)
+    @tracer.close_span(@tracer.current_span())
   end
 
   def phoenix_router_dispatch_exception(
@@ -99,15 +72,7 @@ defmodule Appsignal.Phoenix.EventHandler do
         %{reason: %Plug.Conn.WrapperError{conn: conn, reason: reason, stack: stack}},
         _config
       ) do
-    root_span = @tracer.root_span()
-
-    Logger.debug(fn -> """
-    AppSignal.Phoenix.EventHandler received [:phoenix, :router_dispatch, :exception]:
-      root_span: #{inspect(root_span)}
-      span: #{inspect(@tracer.current_span())}
-    """ end)
-
-    add_error(root_span, conn, reason, stack)
+    add_error(@tracer.root_span(), conn, reason, stack)
   end
 
   def phoenix_router_dispatch_exception(
@@ -116,15 +81,7 @@ defmodule Appsignal.Phoenix.EventHandler do
         %{conn: conn, reason: reason, stacktrace: stack},
         _config
       ) do
-    root_span = @tracer.root_span()
-
-    Logger.debug(fn -> """
-    AppSignal.Phoenix.EventHandler received [:phoenix, :router_dispatch, :exception]:
-      root_span: #{inspect(root_span)}
-      span: #{inspect(@tracer.current_span())}
-    """ end)
-
-    add_error(root_span, conn, reason, stack)
+    add_error(@tracer.root_span(), conn, reason, stack)
   end
 
   defp add_error(
@@ -150,10 +107,10 @@ defmodule Appsignal.Phoenix.EventHandler do
   end
 
   def phoenix_template_render_start(_event, _measurements, metadata, _config) do
-    parent_span = @tracer.current_span()
+    parent = @tracer.current_span()
 
     "http_request"
-    |> @tracer.create_span(parent_span)
+    |> @tracer.create_span(parent)
     |> @span.set_name(
       "Render #{inspect(metadata.template)} (#{metadata.format}) template from #{module_name(metadata.view)}"
     )

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -80,12 +80,13 @@ defmodule Appsignal.Phoenix.EventHandler do
     """ end)
   end
 
-  def phoenix_router_dispatch_stop(_event, _measurements, _metadata, _config) do
+  def phoenix_router_dispatch_stop(_event, _measurements, metadata, _config) do
+    _root_span = set_span_data(@tracer.root_span(), metadata)
     span = @tracer.current_span()
 
     Logger.debug(fn -> """
     AppSignal.Phoenix.EventHandler received [:phoenix, :router_dispatch, :stop]:
-      root_span: #{inspect(@tracer.root_span())}
+      root_span: #{inspect(root_span)}
       span: #{inspect(span)}
     """ end)
 

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -38,31 +38,58 @@ defmodule Appsignal.Phoenix.EventHandler do
   end
 
   def phoenix_endpoint_start(_event, _measurements, _metadata, _config) do
-    parent = @tracer.current_span()
+    parent_span = @tracer.current_span()
 
-    "http_request"
-    |> @tracer.create_span(parent)
+    span = "http_request"
+    |> @tracer.create_span(parent_span)
     |> @span.set_attribute("appsignal:category", "call.phoenix_endpoint")
+
+    Logger.debug(fn -> """
+    AppSignal.Phoenix.EventHandler received [:phoenix, :endpoint, :start]:
+      root_span: #{inspect(@tracer.root_span())}
+      parent_span: #{inspect(parent_span)}
+      span: #{inspect(span)}
+    """ end)
   end
 
   def phoenix_endpoint_stop(_event, _measurements, metadata, _config) do
-    _root_span = set_span_data(@tracer.root_span(), metadata)
+    root_span = set_span_data(@tracer.root_span(), metadata)
+    span = @tracer.current_span()
 
-    @tracer.current_span()
-    |> @tracer.close_span()
+    Logger.debug(fn -> """
+    AppSignal.Phoenix.EventHandler received [:phoenix, :endpoint, :stop]:
+      root_span: #{inspect(root_span)}
+      span: #{inspect(span)}
+    """ end)
+
+    @tracer.close_span(span)
   end
 
   def phoenix_router_dispatch_start(_event, _measurements, _metadata, _config) do
-    parent = @tracer.current_span()
+    parent_span = @tracer.current_span()
 
-    "http_request"
-    |> @tracer.create_span(parent)
+    span = "http_request"
+    |> @tracer.create_span(parent_span)
     |> @span.set_attribute("appsignal:category", "call.phoenix_router_dispatch")
+
+    Logger.debug(fn -> """
+    AppSignal.Phoenix.EventHandler received [:phoenix, :router_dispatch, :start]:
+      root_span: #{inspect(@tracer.root_span())}
+      parent_span: #{inspect(parent_span)}
+      span: #{inspect(span)}
+    """ end)
   end
 
   def phoenix_router_dispatch_stop(_event, _measurements, _metadata, _config) do
-    @tracer.current_span()
-    |> @tracer.close_span()
+    span = @tracer.current_span()
+
+    Logger.debug(fn -> """
+    AppSignal.Phoenix.EventHandler received [:phoenix, :router_dispatch, :stop]:
+      root_span: #{inspect(@tracer.root_span())}
+      span: #{inspect(span)}
+    """ end)
+
+    @tracer.close_span(span)
   end
 
   def phoenix_router_dispatch_exception(
@@ -71,7 +98,15 @@ defmodule Appsignal.Phoenix.EventHandler do
         %{reason: %Plug.Conn.WrapperError{conn: conn, reason: reason, stack: stack}},
         _config
       ) do
-    add_error(@tracer.root_span(), conn, reason, stack)
+    root_span = @tracer.root_span()
+
+    Logger.debug(fn -> """
+    AppSignal.Phoenix.EventHandler received [:phoenix, :router_dispatch, :exception]:
+      root_span: #{inspect(root_span)}
+      span: #{inspect(@tracer.current_span())}
+    """ end)
+
+    add_error(root_span, conn, reason, stack)
   end
 
   def phoenix_router_dispatch_exception(
@@ -80,7 +115,15 @@ defmodule Appsignal.Phoenix.EventHandler do
         %{conn: conn, reason: reason, stacktrace: stack},
         _config
       ) do
-    add_error(@tracer.root_span(), conn, reason, stack)
+    root_span = @tracer.root_span()
+
+    Logger.debug(fn -> """
+    AppSignal.Phoenix.EventHandler received [:phoenix, :router_dispatch, :exception]:
+      root_span: #{inspect(root_span)}
+      span: #{inspect(@tracer.current_span())}
+    """ end)
+
+    add_error(root_span, conn, reason, stack)
   end
 
   defp add_error(
@@ -106,10 +149,10 @@ defmodule Appsignal.Phoenix.EventHandler do
   end
 
   def phoenix_template_render_start(_event, _measurements, metadata, _config) do
-    parent = @tracer.current_span()
+    parent_span = @tracer.current_span()
 
     "http_request"
-    |> @tracer.create_span(parent)
+    |> @tracer.create_span(parent_span)
     |> @span.set_name(
       "Render #{inspect(metadata.template)} (#{metadata.format}) template from #{module_name(metadata.view)}"
     )

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -45,11 +45,8 @@ defmodule Appsignal.Phoenix.EventHandler do
     |> @span.set_attribute("appsignal:category", "call.phoenix_endpoint")
   end
 
-  def phoenix_endpoint_stop(_event, _measurements, metadata, _config) do
-    _root_span = set_span_data(@tracer.root_span(), metadata)
-
-    @tracer.current_span()
-    |> @tracer.close_span()
+  def phoenix_endpoint_stop(_event, _measurements, _metadata, _config) do
+    @tracer.close_span(@tracer.current_span())
   end
 
   def phoenix_router_dispatch_start(_event, _measurements, _metadata, _config) do

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -25,11 +25,6 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
   describe "after receiving an endpoint-start and an endpoint-stop event" do
     setup [:create_root_span, :endpoint_start_event, :endpoint_finish_event]
 
-    test "sets the span's name" do
-      assert {:ok, [{%Span{}, "AppsignalPhoenixExampleWeb.PageController#index"}]} =
-               Test.Span.get(:set_name_if_nil)
-    end
-
     test "sets the root span's category" do
       assert {:ok, [{%Span{}, "appsignal:category", "call.phoenix_endpoint"}]} =
                Test.Span.get(:set_attribute)
@@ -37,47 +32,6 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
 
     test "finishes an event" do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
-    end
-
-    test "sets the root span's parameters" do
-      {:ok, calls} = Test.Span.get(:set_sample_data_if_nil)
-
-      [{%Span{}, "params", params}] =
-        Enum.filter(calls, fn {_span, key, _value} -> key == "params" end)
-
-      assert %{"foo" => "bar"} == params
-    end
-
-    test "sets the root span's sample data" do
-      {:ok, calls} = Test.Span.get(:set_sample_data_if_nil)
-
-      [{%Span{}, "environment", environment}] =
-        Enum.filter(calls, fn {_span, key, _value} -> key == "environment" end)
-
-      assert %{
-               "host" => "www.example.com",
-               "method" => "GET",
-               "port" => 80,
-               "request_id" => nil,
-               "request_path" => "/",
-               "status" => 200
-             } == environment
-    end
-  end
-
-  describe "after receiving an endpoint-start and an endpoint-stop event without an event name in the conn" do
-    setup [:create_root_span, :endpoint_start_event]
-
-    setup do
-      :telemetry.execute(
-        [:phoenix, :endpoint, :stop],
-        %{duration: 49_474_000},
-        %{conn: %Plug.Conn{}, route: "/foo/:bar", options: []}
-      )
-    end
-
-    test "sets the span's name" do
-      assert {:ok, [{%Span{}, "GET /foo/:bar"}]} = Test.Span.get(:set_name_if_nil)
     end
   end
 


### PR DESCRIPTION
Since https://github.com/appsignal/appsignal-elixir-phoenix/pull/90, which was released as 2.4.0, we've started supporting Phoenix's /endpoint/ events, which put us a bit higher in the stack, allowing us to get data from pipeline plugs, for example. It also moved setting root span metadata from an event named `[:phoenix, :router_dispatch, :stop]` to the newly added `[:phoenix, :endpoint, :stop]`.

We've learned since that some applications don't publish the endpoint events. We're still figuring out in which situations that happens, but we know that the integration works even if we don't have an endpoint event, as it will automatically fall back to using the router dispatch event as the root span. However, since we set the request metadata on the endpoint event (which doesn't fire for some apps), the metadata got omitted resulting in spans without names, which get dropped by the agent.

This patch moves the metadata setting back to the :router_dipatch :stop event, which we know all apps have.

https://app.intercom.com/a/inbox/yzor8gyw/inbox/admin/4356044/conversation/16410700348100?view=List
https://app.intercom.com/a/inbox/yzor8gyw/inbox/conversation/16410700349323#part_id=comment-16410700349323-21909570290