### PR TITLE
Record request information as metadata

### DIFF
--- a/.changesets/record-request-information-as-metadata.md
+++ b/.changesets/record-request-information-as-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: add
+---
+
+Record request information as metadata

--- a/.changesets/record-request-information-as-metadata.md
+++ b/.changesets/record-request-information-as-metadata.md
@@ -3,4 +3,4 @@ bump: minor
 type: add
 ---
 
-Record request information as metadata
+Record request information as metadata like the request path, request method and response status.

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -128,8 +128,8 @@ defmodule Appsignal.Phoenix.EventHandler do
     |> @span.set_sample_data_if_nil("session_data", Appsignal.Metadata.session(conn))
     |> @span.set_sample_data("metadata", %{
       "hostname" => appsignal_metadata["host"],
-      "method" => appsignal_metadata["method"],
-      "path" => appsignal_metadata["request_path"],
+      "request_method" => appsignal_metadata["method"],
+      "request_path" => appsignal_metadata["request_path"],
       "request_id" => appsignal_metadata["request_id"],
       "status" => appsignal_metadata["status"]
     })

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -131,7 +131,7 @@ defmodule Appsignal.Phoenix.EventHandler do
       "request_method" => appsignal_metadata["method"],
       "request_path" => appsignal_metadata["request_path"],
       "request_id" => appsignal_metadata["request_id"],
-      "status" => appsignal_metadata["status"]
+      "response_status" => appsignal_metadata["status"]
     })
   end
 

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -127,7 +127,6 @@ defmodule Appsignal.Phoenix.EventHandler do
     |> @span.set_sample_data_if_nil("environment", appsignal_metadata)
     |> @span.set_sample_data_if_nil("session_data", Appsignal.Metadata.session(conn))
     |> @span.set_sample_data("metadata", %{
-      "hostname" => appsignal_metadata["host"],
       "request_method" => appsignal_metadata["method"],
       "request_path" => appsignal_metadata["request_path"],
       "request_id" => appsignal_metadata["request_id"],

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -119,11 +119,20 @@ defmodule Appsignal.Phoenix.EventHandler do
   end
 
   defp set_span_data(span, %{conn: conn} = metadata) do
+    appsignal_metadata = Appsignal.Metadata.metadata(conn)
+
     span
     |> @span.set_name_if_nil(name(metadata))
     |> @span.set_sample_data_if_nil("params", Appsignal.Metadata.params(conn))
-    |> @span.set_sample_data_if_nil("environment", Appsignal.Metadata.metadata(conn))
+    |> @span.set_sample_data_if_nil("environment", appsignal_metadata)
     |> @span.set_sample_data_if_nil("session_data", Appsignal.Metadata.session(conn))
+    |> @span.set_sample_data("metadata", %{
+      "hostname" => appsignal_metadata["host"],
+      "method" => appsignal_metadata["method"],
+      "path" => appsignal_metadata["request_path"],
+      "request_id" => appsignal_metadata["request_id"],
+      "status" => appsignal_metadata["status"]
+    })
   end
 
   defp name(%{conn: conn} = metadata) do

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -97,11 +97,10 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
         Enum.filter(calls, fn {_span, key, _value} -> key == "metadata" end)
 
       assert %{
-               "hostname" => "www.example.com",
-               "method" => "GET",
+               "request_method" => "GET",
                "request_id" => nil,
-               "path" => "/",
-               "status" => 200
+               "request_path" => "/",
+               "response_status" => 200
              } == metadata
     end
   end

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -89,6 +89,21 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
                "status" => 200
              } == environment
     end
+
+    test "sets the root span's metadata" do
+      {:ok, calls} = Test.Span.get(:set_sample_data)
+
+      [{%Span{}, "metadata", metadata}] =
+        Enum.filter(calls, fn {_span, key, _value} -> key == "metadata" end)
+
+      assert %{
+               "hostname" => "www.example.com",
+               "method" => "GET",
+               "request_id" => nil,
+               "path" => "/",
+               "status" => 200
+             } == metadata
+    end
   end
 
   describe "after receiving an router_dispatch-start and an router_dispatch-stop event without an event name in the conn" do


### PR DESCRIPTION
Aside from just adding request information to the environment field, add it to the metadata as well to allow for use in filtering.

Fixes https://github.com/appsignal/support/issues/333.