### PR TITLE
Set render metadata as tags

### DIFF
--- a/.changesets/set-render-metadata-as-tags-on-render-error.md
+++ b/.changesets/set-render-metadata-as-tags-on-render-error.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Set render metadata as tags on render error. When a template rendering error is reported, its backtrace is limited to the Elixir process that is spawned to render the template. Add information about the template and view being rendered as tags, to provide additional context about the error.

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -106,6 +106,13 @@ defmodule Appsignal.Phoenix.EventHandler do
   def phoenix_template_render_start(_event, _measurements, metadata, _config) do
     parent = @tracer.current_span()
 
+    _ =
+      @span.set_sample_data_if_nil(@tracer.root_span(), "tags", %{
+        "phoenix_template" => metadata.template,
+        "phoenix_format" => metadata.format,
+        "phoenix_view" => module_name(metadata.view)
+      })
+
     "http_request"
     |> @tracer.create_span(parent)
     |> @span.set_name(

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -254,6 +254,18 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
       assert {:ok, [{%Span{}, "appsignal:category", "render.phoenix_template"}]} =
                Test.Span.get(:set_attribute)
     end
+
+    test "sets the root span's tags" do
+      assert {:ok,
+              [
+                {%Span{}, "tags",
+                 %{
+                   "phoenix_template" => "template",
+                   "phoenix_format" => "html",
+                   "phoenix_view" => "PhoenixWeb.View"
+                 }}
+              ]} = Test.Span.get(:set_sample_data_if_nil)
+    end
   end
 
   describe "after receiving an render-start and an render-stop event" do


### PR DESCRIPTION
Intercom conversation: https://app.intercom.com/a/inbox/yzor8gyw/inbox/admin/5246522/conversation/16410700366093?view=List

When an error happens during rendering, the backtrace of it is limited to the Elixir process that is spawned for the rendering task, lacking any context from the customer's own code. To ameliorate this issue, add the rendering metadata as tags to the root span, providing some additional context in the resulting error sample.