### PR TITLE
Add live_component update event handling

### DIFF
--- a/.changesets/handle-live-component-update-events.md
+++ b/.changesets/handle-live-component-update-events.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: add
+---
+
+Handle live component update events

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -55,7 +55,8 @@ defmodule Appsignal.Phoenix.LiveView do
       [:phoenix, :live_view, :handle_params],
       [:phoenix, :live_view, :handle_event],
       [:phoenix, :live_view, :render],
-      [:phoenix, :live_component, :handle_event]
+      [:phoenix, :live_component, :handle_event],
+      [:phoenix, :live_component, :update]
     ]
     |> Enum.each(fn event ->
       name = Enum.join(event, ".")


### PR DESCRIPTION
Much like the events already handled, the live_component update event, which is triggered whenever live components are updated.

Closes #102