### PR TITLE
Remove double close calls on spans

### DIFF
--- a/.changesets/update-update-appsignal_plug-dependency-requirement.md
+++ b/.changesets/update-update-appsignal_plug-dependency-requirement.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Update `appsignal_plug` dependency requirement. This fixes an issue with spans being closed double, which led to inaccurate reporting.

--- a/lib/appsignal_phoenix/channel.ex
+++ b/lib/appsignal_phoenix/channel.ex
@@ -52,7 +52,6 @@ defmodule Appsignal.Phoenix.Channel do
               |> @span.set_sample_data_if_nil("params", params)
               |> @span.set_sample_data_if_nil("environment", Appsignal.Metadata.metadata(socket))
               |> @span.add_error(kind, reason, stack)
-              |> @tracer.close_span()
 
             @tracer.ignore()
             :erlang.raise(kind, reason, stack)

--- a/lib/appsignal_phoenix/live_view.ex
+++ b/lib/appsignal_phoenix/live_view.ex
@@ -24,7 +24,6 @@ defmodule Appsignal.Phoenix.LiveView do
               |> @span.set_sample_data_if_nil("params", params)
               |> @span.set_sample_data_if_nil("environment", Appsignal.Metadata.metadata(socket))
               |> @span.add_error(kind, reason, stack)
-              |> @tracer.close_span()
 
             @tracer.ignore()
             :erlang.raise(kind, reason, stack)

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Appsignal.Phoenix.MixProject do
 
     [
       {:appsignal, ">= 2.11.0 and < 3.0.0"},
-      {:appsignal_plug, ">= 2.0.15 and < 3.0.0"},
+      {:appsignal_plug, ">= 2.1.0 and < 3.0.0"},
       {:phoenix, System.get_env("PHOENIX_VERSION", "~> 1.4")},
       {:phoenix_html, "~> 2.11 or ~> 3.0 or ~> 4.0", optional: true},
       {:phoenix_live_view, phoenix_live_view_version, optional: true},


### PR DESCRIPTION
## Update appsignal_plug dependency

Update the dependency so all new packages use the fix linked below that ensures that spans created by our plug package aren't trying to close twice.

See also PR https://github.com/appsignal/appsignal-elixir-plug/pull/51 and PR https://github.com/appsignal/appsignal-elixir/pull/979

## Remove double close calls on spans

The tests failed because the spans were closed twice. Remove the close span call in this package and rely on the `Appsignal.instrument` helper's behavior to close a span if an error occurred in the instrumented function.

See also PR https://github.com/appsignal/appsignal-elixir-plug/pull/51 and PR https://github.com/appsignal/appsignal-elixir/pull/979
