### PR TITLE
Bump AppSignal package to version 2.15.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     [
-      {:appsignal, ">= 2.11.0 and < 3.0.0"},
+      {:appsignal, ">= 2.15.0 and < 3.0.0"},
       {:appsignal_plug, ">= 2.1.0 and < 3.0.0"},
       {:phoenix, System.get_env("PHOENIX_VERSION", "~> 1.4")},
       {:phoenix_html, "~> 2.11 or ~> 3.0 or ~> 4.0", optional: true},


### PR DESCRIPTION
Update the minimal requirement so that it matches the appsignal_plug package's requirement. It just makes it consistent.

[skip changeset]
[skip review]