### PR TITLE
Remove unused hackney dependency

### DIFF
--- a/.changesets/remove-hackney-dependency--not-used.md
+++ b/.changesets/remove-hackney-dependency--not-used.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: change
+---
+
+Remove the Hackney dependency. It is no longer used since AppSignal package 2.15.0.

--- a/mix.exs
+++ b/mix.exs
@@ -61,8 +61,7 @@ defmodule Appsignal.Phoenix.MixProject do
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:credo, credo_version, only: [:dev, :test], runtime: false},
       {:poison, "~> 5.0", only: [:dev, :test], runtime: false},
-      {:telemetry, "~> 0.4 or ~> 1.0"},
-      {:hackney, "~> 1.6"}
+      {:telemetry, "~> 0.4 or ~> 1.0"}
     ]
   end
 end


### PR DESCRIPTION
Remove the dependency so we don't include a dependency that's no longer used by the main AppSignal package.

[skip review]