### PR TITLE
Remove poison dependency

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,8 +7,6 @@ if Mix.env() == :test do
   config :appsignal, appsignal_span: Appsignal.Test.Span
   config :appsignal_plug, os: FakeOS
 
-  config :phoenix, :json_library, Poison
-
   config :appsignal, :config,
     push_api_key: "00000000-0000-0000-0000-000000000000",
     name: "appsignal-plug",

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,6 @@ defmodule Appsignal.Phoenix.MixProject do
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:credo, credo_version, only: [:dev, :test], runtime: false},
-      {:poison, "~> 5.0", only: [:dev, :test], runtime: false},
       {:telemetry, "~> 0.4 or ~> 1.0"}
     ]
   end


### PR DESCRIPTION
Use the phoenix default json lib (Jason for now).

[skip review]
[skip changeset], because it's an internal change for a test library.