### PR TITLE
Add Phoenix 1.8 RC to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
           - elixir: latest
             otp: 27.x
             phoenix: "~> 1.7.0"
+          - elixir: 1.17.x
+            otp: 27.x
+            phoenix: "~> 1.8.0-rc"
           - elixir: 1.16.x
             otp: 26.x
             phoenix: "~> 1.7.0"

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 import Config
 
 if Mix.env() == :test do
-  config :logger, level: :warn
+  config :logger, level: :warning
 
   config :appsignal, appsignal_tracer: Appsignal.Test.Tracer
   config :appsignal, appsignal_span: Appsignal.Test.Span

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -313,7 +313,12 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
       %{time: -576_460_736_044_040_000},
       %{
         conn: %Plug.Conn{private: %{phoenix_endpoint: PhoenixWeb.Endpoint}},
-        options: []
+        plug: AppsignalPhoenixExampleWeb.PageController,
+        plug_opts: :index,
+        route: "/",
+        path_params: %{},
+        pipe_through: [:browser],
+        log: :info
       }
     )
   end
@@ -322,7 +327,15 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
     :telemetry.execute(
       [:phoenix, :router_dispatch, :stop],
       %{duration: 49_474_000},
-      %{conn: conn(), route: "/foo/:bar", options: []}
+      %{
+        conn: conn(),
+        plug: AppsignalPhoenixExampleWeb.PageController,
+        plug_opts: :index,
+        route: "/foo/:bar",
+        path_params: %{},
+        pipe_through: [:browser],
+        log: :info
+      }
     )
   end
 

--- a/test/appsignal_phoenix/live_view_test.exs
+++ b/test/appsignal_phoenix/live_view_test.exs
@@ -2,6 +2,8 @@ defmodule Appsignal.Phoenix.LiveViewTest do
   use ExUnit.Case
   alias Appsignal.{Span, Test}
 
+  def __live__, do: %{log: :info}
+
   setup do
     start_supervised!(Test.Tracer)
     start_supervised!(Test.Span)
@@ -319,7 +321,8 @@ defmodule Appsignal.Phoenix.LiveViewTest do
         %{
           params: %{foo: "bar"},
           session: %{bar: "baz"},
-          socket: %Phoenix.LiveView.Socket{view: __MODULE__}
+          socket: %Phoenix.LiveView.Socket{view: __MODULE__},
+          uri: "http://localhost/"
         }
       )
     end
@@ -431,7 +434,9 @@ defmodule Appsignal.Phoenix.LiveViewTest do
         %{monotonic_time: -576_457_566_461_433_920, system_time: 1_653_474_764_790_125_080},
         %{
           params: %{foo: "bar"},
-          socket: %Phoenix.LiveView.Socket{view: __MODULE__}
+          socket: %Phoenix.LiveView.Socket{view: __MODULE__},
+          component: __MODULE__,
+          event: "handle_event"
         }
       )
     end
@@ -479,7 +484,9 @@ defmodule Appsignal.Phoenix.LiveViewTest do
         %{monotonic_time: -576_457_566_461_433_920, system_time: 1_653_474_764_790_125_080},
         %{
           params: %{foo: "bar"},
-          socket: %Phoenix.LiveView.Socket{view: __MODULE__}
+          socket: %Phoenix.LiveView.Socket{view: __MODULE__},
+          component: __MODULE__,
+          assigns_sockets: [{{}, %Phoenix.LiveView.Socket{view: __MODULE__}}]
         }
       )
     end
@@ -526,8 +533,13 @@ defmodule Appsignal.Phoenix.LiveViewTest do
 
       :telemetry.execute(
         [:phoenix, :live_view, :mount, :stop],
-        %{},
-        %{}
+        %{duration: 100_000},
+        %{
+          socket: %Phoenix.LiveView.Socket{view: __MODULE__},
+          params: %{foo: "bar"},
+          session: %{bar: "baz"},
+          uri: "http://localhost/"
+        }
       )
     end
 
@@ -553,8 +565,16 @@ defmodule Appsignal.Phoenix.LiveViewTest do
 
       :telemetry.execute(
         [:phoenix, :live_view, :mount, :exception],
-        %{},
-        %{kind: :error, reason: reason, stacktrace: []}
+        %{duration: 100_000},
+        %{
+          socket: %Phoenix.LiveView.Socket{view: __MODULE__},
+          params: %{foo: "bar"},
+          session: %{bar: "baz"},
+          uri: "http://localhost/",
+          kind: :error,
+          reason: reason,
+          stacktrace: []
+        }
       )
 
       [reason: reason]

--- a/test/support/phoenix_web.ex
+++ b/test/support/phoenix_web.ex
@@ -12,7 +12,7 @@ defmodule PhoenixWeb.Endpoint do
 end
 
 defmodule PhoenixWeb.Controller do
-  use Phoenix.Controller, namespace: PhoenixWeb
+  use Phoenix.Controller, formats: [:html]
   import Plug.Conn
 
   def index(conn, _params) do

--- a/test/support/phoenix_web.ex
+++ b/test/support/phoenix_web.ex
@@ -7,7 +7,6 @@ end
 
 defmodule PhoenixWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :phoenix_web
-  use Appsignal.Phoenix
 
   plug(PhoenixWeb.Router)
 end


### PR DESCRIPTION
## Add Phoenix 1.8 RC to the CI

Test the latest Phoenix release candidate on CI to see what doesn't work.

[skip changeset]

## Remove 'use Appsignal.Phoenix' from test endpoint

The Phoenix instrumentation happens automatically and the `use Appsignal.Phoenix` line is no longer needed.

## Fix Phoenix.Controller deprecation warnings

Replace deprecated namespace option with formats option to specify supported response formats, fixing warnings in Phoenix 1.8.

## Fix logger level deprecation warning

Change logger level from :warn to :warning to fix deprecation warning in newer Elixir versions.

## Fix telemetry handler compatibility issues

Resolve all Phoenix.Logger and Phoenix.LiveView.Logger badmatch errors by:

Fixed router_dispatch telemetry events to include all expected fields: Added plug, plug_opts, route, path_params, pipe_through, log fields.

Fixed LiveView telemetry events to include all expected fields:
- Added missing uri field to mount events
- Added component and event fields to live_component events
- Added proper metadata structure for all stop/exception events

Added __live__/0 callback to LiveViewTest module to provide log configuration, fixing :undef errors in Phoenix.LiveView.Logger

All telemetry events now match the structure expected by Phoenix's built-in loggers, eliminating handler failures during test execution.

---

[skip changeset]
[skip review]