### PR TITLE
Test against the final Phoenix 1.8 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
         phoenix:
           - "~> 1.6.0"
           - "~> 1.7.0"
+          - "~> 1.8.0"
         include:
           - elixir: main
             otp: 27.x
@@ -119,9 +120,6 @@ jobs:
           - elixir: latest
             otp: 27.x
             phoenix: "~> 1.7.0"
-          - elixir: 1.17.x
-            otp: 27.x
-            phoenix: "~> 1.8.0-rc"
           - elixir: 1.16.x
             otp: 26.x
             phoenix: "~> 1.7.0"


### PR DESCRIPTION
It's been released, we don't need to test against the release candidate.

[skip changeset]
[skip review]