### PR TITLE
CI/CD - use custom env to identify CI/CD run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,18 @@ name: Elixir Phoenix package CI
 on:
   push:
     branches:
-    - main
-    - develop
+      - main
+      - develop
   pull_request:
     types:
-    - opened
-    - reopened
-    - synchronize
+      - opened
+      - reopened
+      - synchronize
   schedule:
     - cron: "0 0 * * 1-5"
   workflow_dispatch:
+env:
+  CONTRIBUTION_CI: "true"
 
 jobs:
   lint_git:

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Appsignal.Phoenix.MixProject do
       end
 
     phoenix_version =
-      case {System.get_env("CI"), System.get_env("PHOENIX_VERSION")} do
+      case {System.get_env("CONTRIBUTION_CI"), System.get_env("PHOENIX_VERSION")} do
         {"true", nil} ->
           raise "PHOENIX_VERSION environment variable must be set on CI"
 


### PR DESCRIPTION
Use custom env in CI/CD flow to identify it runs own GH Action runs for this package and not CI/CD of application which use this package as deps.

Last release `2.8.0` introduced this change:
<img width="1648" height="570" alt="CleanShot 2025-11-21 at 06 42 38@2x" src="https://github.com/user-attachments/assets/fe47fd39-c9b5-4ca7-95bd-c2badba953f3" />
See more here https://diff.hex.pm/diff/appsignal_phoenix/2.7.0..2.8.0

and it means that when users(developers) who use this package as deps run CI/CD and `CI` env is available it require to have configured `PHOENIX_VERSION` env. See error from our CI/CD:

```
Error while loading project :appsignal_phoenix at /home/runner/work/enaia/enaia/deps/appsignal_phoenix
** (RuntimeError) PHOENIX_VERSION environment variable must be set on CI
    /home/runner/work/enaia/enaia/deps/appsignal_phoenix/mix.exs:63: Appsignal.Phoenix.MixProject.deps/0
    /home/runner/work/enaia/enaia/deps/appsignal_phoenix/mix.exs:17: Appsignal.Phoenix.MixProject.project/0
    (mix 1.19.3) lib/mix/project.ex:1093: Mix.Project.get_project_config/1
    (mix 1.19.3) lib/mix/project.ex:299: Mix.Project.push_config/2
    (mix 1.19.3) lib/mix/project.ex:262: Mix.Project.push/3
    (stdlib 7.1) lists.erl:2466: :lists.foldl/3
```

So I added custom env flag which will prevent this error. 