### PR TITLE
Close the span each Phoenix event handler opened

### DIFF
--- a/.changesets/fix-missing-traces-for-instrumented-responses.md
+++ b/.changesets/fix-missing-traces-for-instrumented-responses.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: fix
+---
+
+Fix traces going missing when a Phoenix response is sent from inside an instrumented block. This happens when `Appsignal.instrument/2`, or a function decorated with `transaction_event()`, wraps a call that sends the response, such as `render/2` or `redirect/2`.
+
+On web servers that serve more than one request per process, such as Bandit, this also affected the requests that followed on the same connection. Those requests were not reported at all, and an error reported by one of them could show the action, parameters, environment and session data of an earlier request. On Cowboy, where each request gets its own process, only the request that sent its response inside an instrumented block was affected.

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ appsignal_phoenix-*.tar
 
 # Ignore lock file to use latest versions of dependencies.
 mix.lock
+
+# The persistent lookup tables "mix dialyzer" builds.
+/priv/plts/

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -5,6 +5,19 @@ defmodule Appsignal.Phoenix.EventHandler do
 
   require Logger
 
+  # Each start handler remembers the span it created, so that its stop handler
+  # closes that span rather than whichever span happens to be the current one.
+  # Anything else opening a span in between, such as a call to
+  # `Appsignal.instrument/2`, would otherwise shift which span gets closed.
+  #
+  # These are stacks because `Phoenix.Router.forward` re-enters the router, so
+  # the router dispatch events nest.
+  @endpoint_key {__MODULE__, :endpoint_spans}
+  @dispatch_key {__MODULE__, :router_dispatch_spans}
+  @render_key {__MODULE__, :render_spans}
+  @route_key {__MODULE__, :route}
+  @root_span_data_key {__MODULE__, :root_span_data_set}
+
   def attach do
     handlers = %{
       [:phoenix, :endpoint, :start] => &__MODULE__.phoenix_endpoint_start/4,
@@ -38,29 +51,57 @@ defmodule Appsignal.Phoenix.EventHandler do
   end
 
   def phoenix_endpoint_start(_event, _measurements, _metadata, _config) do
+    start_request()
+
     parent = @tracer.current_span()
 
     "http_request"
     |> @tracer.create_span(parent)
     |> @span.set_attribute("appsignal:category", "call.phoenix_endpoint")
+    |> push(@endpoint_key)
   end
 
-  def phoenix_endpoint_stop(_event, _measurements, _metadata, _config) do
-    @tracer.close_span(@tracer.current_span())
+  def phoenix_endpoint_stop(_event, _measurements, metadata, _config) do
+    span = pop(@endpoint_key)
+
+    # This event fires from a `register_before_send` callback, so it arrives
+    # before the router dispatch stop event does. The root span has to be
+    # described here, because it is closed below and cannot be described
+    # afterwards.
+    _ = Process.put(@root_span_data_key, true)
+    _root_span = set_span_data(@tracer.root_span(), with_route(metadata))
+
+    @tracer.close_span(span)
   end
 
-  def phoenix_router_dispatch_start(_event, _measurements, _metadata, _config) do
+  def phoenix_router_dispatch_start(_event, _measurements, metadata, _config) do
+    # A Phoenix router can be dispatched to without a Phoenix endpoint, for
+    # example when a Plug application forwards to one. There is no endpoint
+    # start event to begin the request then, so this handler begins it instead.
+    start_request()
+
+    # The endpoint stop event does not carry the route, and it arrives before
+    # the router dispatch stop event that does. Remember the route so that the
+    # endpoint stop handler can still fall back to naming the span after it.
+    _ = put_route(metadata)
+
     parent = @tracer.current_span()
 
     "http_request"
     |> @tracer.create_span(parent)
     |> @span.set_attribute("appsignal:category", "call.phoenix_router_dispatch")
+    |> push(@dispatch_key)
   end
 
   def phoenix_router_dispatch_stop(_event, _measurements, metadata, _config) do
-    _root_span = set_span_data(@tracer.root_span(), metadata)
+    span = pop(@dispatch_key)
 
-    @tracer.close_span(@tracer.current_span())
+    # A Phoenix router can be dispatched to without a Phoenix endpoint, for
+    # example when a Plug application forwards to one. There is no endpoint stop
+    # event to describe the root span then, so this handler does it instead.
+    _root_span = set_root_span_data_unless_set(metadata)
+
+    @tracer.close_span(span)
   end
 
   def phoenix_router_dispatch_exception(
@@ -100,6 +141,11 @@ defmodule Appsignal.Phoenix.EventHandler do
     |> set_span_data(%{conn: conn})
     |> @tracer.close_span()
 
+    # No stop event arrives for the spans this request opened, so nothing else
+    # will take them off the stacks. On a web server that serves more than one
+    # request per process, such as Bandit, they would pile up.
+    forget()
+
     @tracer.ignore()
   end
 
@@ -119,10 +165,11 @@ defmodule Appsignal.Phoenix.EventHandler do
       "Render #{inspect(metadata.template)} (#{metadata.format}) template from #{module_name(metadata.view)}"
     )
     |> @span.set_attribute("appsignal:category", "render.phoenix_template")
+    |> push(@render_key)
   end
 
   def phoenix_template_render_stop(_event, _measurements, _metadata, _config) do
-    @tracer.close_span(@tracer.current_span())
+    @tracer.close_span(pop(@render_key))
   end
 
   defp set_span_data(span, %{conn: conn} = metadata) do
@@ -156,4 +203,66 @@ defmodule Appsignal.Phoenix.EventHandler do
   defp module_name("Elixir." <> module), do: module
   defp module_name(module) when is_binary(module), do: module
   defp module_name(module), do: module |> to_string() |> module_name()
+
+  # A request starting in this process takes over from whatever request ran in
+  # it before. On a web server that serves more than one request per process,
+  # such as Bandit, what the previous request left behind is still here, and
+  # using any of it would describe this request with the last one's data.
+  defp start_request do
+    _ = Process.delete(@root_span_data_key)
+    _ = Process.delete(@route_key)
+
+    :ok
+  end
+
+  defp set_root_span_data_unless_set(metadata) do
+    case Process.get(@root_span_data_key) do
+      true ->
+        nil
+
+      _ ->
+        _ = Process.put(@root_span_data_key, true)
+        set_span_data(@tracer.root_span(), metadata)
+    end
+  end
+
+  defp put_route(%{route: route}) when is_binary(route) do
+    _ = Process.put(@route_key, route)
+  end
+
+  defp put_route(_metadata), do: nil
+
+  defp with_route(metadata) do
+    case Process.get(@route_key) do
+      nil -> metadata
+      route -> Map.put_new(metadata, :route, route)
+    end
+  end
+
+  defp push(span, key) do
+    _ = Process.put(key, [span | Process.get(key, [])])
+    span
+  end
+
+  # Returns `nil` when no span was pushed, which happens when AppSignal starts
+  # in the middle of a request, or when the process is ignored. Deliberately
+  # does not fall back to the current span: closing a span that this handler did
+  # not open is the bug this bookkeeping exists to prevent.
+  defp pop(key) do
+    case Process.get(key, []) do
+      [span | rest] ->
+        _ = Process.put(key, rest)
+        span
+
+      [] ->
+        nil
+    end
+  end
+
+  defp forget do
+    Enum.each(
+      [@endpoint_key, @dispatch_key, @render_key, @route_key, @root_span_data_key],
+      &Process.delete/1
+    )
+  end
 end

--- a/test/appsignal_phoenix/event_handler_request_test.exs
+++ b/test/appsignal_phoenix/event_handler_request_test.exs
@@ -1,0 +1,288 @@
+defmodule Appsignal.Phoenix.EventHandlerRequestTest do
+  # Tests the event handler against whole request sequences, rather than against
+  # pairs of events in isolation.
+  #
+  # `Plug.Telemetry` emits the endpoint stop event from a `register_before_send`
+  # callback, so it fires inside whatever code sends the response. That is why
+  # the endpoint stop event appears in the middle of these sequences instead of
+  # at the end.
+  use ExUnit.Case
+  alias Appsignal.{Span, Test, Tracer}
+
+  setup do
+    start_supervised!(Test.Tracer)
+    start_supervised!(Test.Span)
+
+    # No root span is created here on purpose. In a Phoenix application that
+    # does not `use Appsignal.Plug`, the endpoint span is the root span.
+    :ok
+  end
+
+  describe "after a request" do
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+      render_start()
+      render_stop()
+      endpoint_stop()
+      router_dispatch_stop()
+    end
+
+    test "leaves no spans behind" do
+      assert [] == Tracer.lookup(self())
+    end
+  end
+
+  describe "after a request that renders inside an instrumented block" do
+    setup do
+      endpoint_start()
+      endpoint_span = Tracer.current_span()
+
+      router_dispatch_start()
+
+      Appsignal.instrument("event.group", fn _span ->
+        render_start()
+        render_stop()
+        endpoint_stop()
+      end)
+
+      router_dispatch_stop()
+
+      [endpoint_span: endpoint_span]
+    end
+
+    test "leaves no spans behind" do
+      assert [] == Tracer.lookup(self())
+    end
+
+    test "closes the endpoint span", %{endpoint_span: endpoint_span} do
+      {:ok, calls} = Test.Tracer.get(:close_span)
+
+      assert Enum.any?(calls, fn
+               {^endpoint_span} -> true
+               _ -> false
+             end)
+    end
+  end
+
+  describe "after a request that redirects inside an instrumented block" do
+    # The shape of a `redirect(conn, to: ...) |> halt()` inside a function
+    # decorated with `transaction_event()`. The response is sent, and therefore
+    # the endpoint stop event fires, before the instrumented block returns.
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+
+      Appsignal.instrument("event.group", fn _span ->
+        endpoint_stop()
+      end)
+
+      router_dispatch_stop()
+    end
+
+    test "leaves no spans behind" do
+      assert [] == Tracer.lookup(self())
+    end
+  end
+
+  describe "after two requests in the same process" do
+    # Bandit serves every keep-alive request on a connection from one process,
+    # so a second request can start in a process that has already served one.
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+
+      Appsignal.instrument("event.group", fn _span ->
+        endpoint_stop()
+      end)
+
+      router_dispatch_stop()
+
+      endpoint_start()
+    end
+
+    test "starts a root span for the second request" do
+      # `Appsignal.Test.Tracer` records calls with the most recent one first.
+      assert {:ok, [{"http_request", nil} | _]} = Test.Tracer.get(:create_span)
+    end
+  end
+
+  describe "after a request that is halted before it reaches the router" do
+    setup do
+      endpoint_start()
+      endpoint_stop()
+    end
+
+    test "sets the root span's parameters" do
+      {:ok, calls} = Test.Span.get(:set_sample_data_if_nil)
+
+      assert [{%Span{}, "params", %{"foo" => "bar"}}] =
+               Enum.filter(calls, fn {_span, key, _value} -> key == "params" end)
+    end
+
+    test "leaves no spans behind" do
+      assert [] == Tracer.lookup(self())
+    end
+  end
+
+  describe "after a routed request, then one halted before the router" do
+    # Both requests run in the same process, as they do on Bandit. The second
+    # one never reaches the router, so it has no route of its own.
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+      endpoint_stop()
+      router_dispatch_stop()
+
+      endpoint_start()
+      endpoint_stop(conn_without_route_info())
+    end
+
+    test "does not name the second request after the first request's route" do
+      {:ok, calls} = Test.Span.get(:set_name_if_nil)
+      names = Enum.map(calls, fn {_span, name} -> name end)
+
+      refute "GET /" in names
+    end
+  end
+
+  describe "after an endpoint request, then a router dispatch without an endpoint" do
+    # A Plug application that forwards to a Phoenix router emits the router
+    # dispatch events without the endpoint ones. The endpoint request before it
+    # must not stop the router dispatch from describing the root span.
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+      endpoint_stop()
+      router_dispatch_stop()
+
+      router_dispatch_start()
+      router_dispatch_stop()
+    end
+
+    test "describes the root span of both requests" do
+      {:ok, calls} = Test.Span.get(:set_name_if_nil)
+
+      assert length(calls) == 2
+    end
+  end
+
+  describe "after a forwarded router dispatch without an endpoint" do
+    # Nested router dispatch events, with no endpoint events around them. Only
+    # the first dispatch stop to run should describe the root span.
+    setup do
+      router_dispatch_start()
+      router_dispatch_start()
+      router_dispatch_stop()
+      router_dispatch_stop()
+    end
+
+    test "describes the root span once" do
+      {:ok, calls} = Test.Span.get(:set_name_if_nil)
+
+      assert length(calls) == 1
+    end
+  end
+
+  describe "after a request that is dispatched through a forwarded router" do
+    # `Phoenix.Router.forward` re-enters the router, so the router dispatch
+    # events nest.
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+      router_dispatch_start()
+      endpoint_stop()
+      router_dispatch_stop()
+      router_dispatch_stop()
+    end
+
+    test "leaves no spans behind" do
+      assert [] == Tracer.lookup(self())
+    end
+  end
+
+  defp endpoint_start do
+    :telemetry.execute(
+      [:phoenix, :endpoint, :start],
+      %{system_time: -576_460_736_044_040_000},
+      %{conn: %Plug.Conn{private: %{phoenix_endpoint: PhoenixWeb.Endpoint}}, options: []}
+    )
+  end
+
+  defp endpoint_stop(conn \\ conn()) do
+    # `Plug.Telemetry` emits this event with only the conn and its own options.
+    # It does not include the route.
+    :telemetry.execute(
+      [:phoenix, :endpoint, :stop],
+      %{duration: 49_474_000},
+      %{conn: conn, options: []}
+    )
+  end
+
+  defp router_dispatch_start do
+    :telemetry.execute(
+      [:phoenix, :router_dispatch, :start],
+      %{system_time: -576_460_736_044_040_000},
+      %{
+        conn: %Plug.Conn{private: %{phoenix_endpoint: PhoenixWeb.Endpoint}},
+        plug: AppsignalPhoenixExampleWeb.PageController,
+        plug_opts: :index,
+        route: "/",
+        path_params: %{},
+        pipe_through: [:browser],
+        log: :info
+      }
+    )
+  end
+
+  defp router_dispatch_stop do
+    :telemetry.execute(
+      [:phoenix, :router_dispatch, :stop],
+      %{duration: 49_474_000},
+      %{
+        conn: conn(),
+        plug: AppsignalPhoenixExampleWeb.PageController,
+        plug_opts: :index,
+        route: "/foo/:bar",
+        path_params: %{},
+        pipe_through: [:browser],
+        log: :info
+      }
+    )
+  end
+
+  defp render_start do
+    :telemetry.execute(
+      [:phoenix, :controller, :render, :start],
+      %{system_time: -576_460_736_044_040_000},
+      %{view: PhoenixWeb.View, template: "template", format: "html"}
+    )
+  end
+
+  defp render_stop do
+    :telemetry.execute([:phoenix, :controller, :render, :stop], %{duration: 49_474_000}, %{})
+  end
+
+  defp conn do
+    %Plug.Conn{
+      params: %{"foo" => "bar"},
+      private: %{
+        phoenix_action: :index,
+        phoenix_controller: AppsignalPhoenixExampleWeb.PageController
+      },
+      port: 80,
+      request_path: "/",
+      status: 200
+    }
+  end
+
+  defp conn_without_route_info do
+    %Plug.Conn{
+      params: %{"foo" => "bar"},
+      private: %{},
+      port: 80,
+      request_path: "/",
+      status: 200
+    }
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/appsignal/appsignal-elixir-phoenix/issues/115.

### [Ignore the dialyzer lookup tables](https://github.com/appsignal/appsignal-elixir-phoenix/commit/37e043f1e7e4a9f37f2d422f50e586916bdac090)

Running `mix dialyzer` locally writes a persistent lookup table to
`priv/plts/`, which is where `mix.exs` configures it to go. It is a
build artifact of about two megabytes, and it was showing up as an
untracked file that is easy to commit by accident.

### [Add tests for whole Phoenix request sequences](https://github.com/appsignal/appsignal-elixir-phoenix/commit/3e154e5ab3c6531a4dcd8a61fc4aa96ac1b66f94)

The event handler is tested against pairs of telemetry events in
isolation. That misses what happens across a whole request, which is
where the handler gets its span bookkeeping wrong.

`Plug.Telemetry` emits the endpoint stop event from a
`register_before_send` callback. That means it fires inside whatever
code sends the response. When a response is sent from inside an
instrumented block, the handler closes that block's span instead of its
own, and the root span is never closed.

Two things follow from that. The trace is never sent, because the
extension completes a trace when its root span closes. The root span
also stays in the registry, so on Bandit, where one process serves every
keep-alive request on a connection, the next request on that connection
becomes a child of the leaked root span instead of starting its own
trace.

Five of these tests fail for that reason. The other three are controls
for the sequences that already work today.

### [Close the span each Phoenix event handler opened](https://github.com/appsignal/appsignal-elixir-phoenix/commit/88658db18fe5ccba9a132ef6d9d21ae4633705c7)

Every stop handler closed whichever span was current, rather than the
span its own start handler opened. That works only while spans open and
close in a strict order, and anything else opening a span in between
breaks it.

`Plug.Telemetry` emits the endpoint stop event from a
`register_before_send` callback, so it fires inside whatever code sends
the response. A response sent from inside a call to
`Appsignal.instrument/2` therefore closed that call's span, and the root
span was left open. The trace was never sent, and the root span stayed
in the registry, where a later request in the same process picked it up
as its parent.

Each start handler now remembers the span it opened, and each stop
handler closes that span. When there is nothing to close, the handler
does nothing rather than falling back to the current span.

Closing the root span at the endpoint stop event means the root span has
to be described there too, because the router dispatch stop event
arrives afterwards. The router dispatch handler still describes the root
span when no endpoint stop event arrives, which is what happens when a
Plug application forwards to a Phoenix router. That event carries the
route and the endpoint stop event does not, so the route is remembered
when the dispatch starts.

The remembered route, and whether the root span has been described
already, are both kept per process. Both are cleared when a request
starts. On a web server that serves more than one request per process,
such as Bandit, what one request left behind would otherwise be used to
describe the next one.

One behaviour changes as a result. A request that is halted before it
reaches the router now has its parameters, environment and session data
reported, where before it had none.
