### PR TITLE
Fix the test builds for older Elixir versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,9 +154,11 @@ jobs:
           - elixir: 1.14.x
             otp: 25.x
             phoenix: "~> 1.7.0"
+            plug: "~> 1.19.0"
           - elixir: 1.14.x
             otp: 25.x
             phoenix: "~> 1.6.0"
+            plug: "~> 1.19.0"
           - elixir: 1.13.x
             otp: 24.x
             phoenix: "~> 1.7.0"
@@ -176,11 +178,11 @@ jobs:
           - elixir: 1.11.x
             otp: 24.x
             phoenix: "~> 1.7.0"
-            plug: "~> 1.18.0"
+            plug: "~> 1.18.0 and < 1.18.2"
           - elixir: 1.11.x
             otp: 24.x
             phoenix: "~> 1.6.0"
-            plug: "~> 1.18.0"
+            plug: "~> 1.18.0 and < 1.18.2"
 
     steps:
       - name: Set up Erlang and Elixir

--- a/mix.exs
+++ b/mix.exs
@@ -66,6 +66,26 @@ defmodule Appsignal.Phoenix.MixProject do
         version -> [{:plug, version, override: true}]
       end
 
+    # Finch 0.22 requires Elixir 1.15 or newer, and so does HPAX 1.0.4, which
+    # Finch pulls in through Mint. The lock file is not checked in, so every
+    # build resolves the newest version of both, and neither compiles on older
+    # Elixir versions. Cap them there.
+    #
+    # Both are transitive dependencies through the AppSignal package. On newer
+    # Elixir versions they are left out of the dependency list entirely, so
+    # these caps are never imposed on the published package.
+    finch_dependencies =
+      case Version.compare(system_version, "1.15.0") do
+        :lt ->
+          [
+            {:finch, ">= 0.19.0 and < 0.22.0"},
+            {:hpax, ">= 1.0.0 and < 1.0.4", override: true}
+          ]
+
+        _ ->
+          []
+      end
+
     [
       {:appsignal, ">= 2.15.0 and < 3.0.0"},
       {:appsignal_plug, ">= 2.1.0 and < 3.0.0"},
@@ -76,6 +96,6 @@ defmodule Appsignal.Phoenix.MixProject do
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:credo, credo_version, only: [:dev, :test], runtime: false},
       {:telemetry, "~> 0.4 or ~> 1.0"}
-    ] ++ plug_override
+    ] ++ plug_override ++ finch_dependencies
   end
 end


### PR DESCRIPTION
The builds for Elixir 1.11 through 1.14 have been failing on `main` since 2026-05-12. Each failure is a dependency that resolved to a version its Elixir cannot compile. The lock file is not checked in, so every build resolves the newest version of everything.

### [Cap Finch and HPAX on older Elixir versions](https://github.com/appsignal/appsignal-elixir-phoenix/commit/63c93185b03e625cfcfc8a3d33888c38a1c37644)

Finch 0.22 requires Elixir 1.15 or newer, and so does HPAX 1.0.4, which
Finch pulls in through Mint. Both are transitive dependencies of this
package through the AppSignal package.

The lock file is not checked in, so every build resolves the newest
version of both. Since Finch 0.22 was released, the builds for Elixir
1.11 through 1.14 have failed to compile it. Since HPAX 1.0.4 was
released, they have failed on that instead.

Cap both on the Elixir versions that cannot compile them, following what
the AppSignal for Elixir and AppSignal for Plug packages already do. The
caps only apply below Elixir 1.15, so they are never imposed on the
published package, which is built on a newer version.

### [Pin Plug per Elixir version in the test matrix](https://github.com/appsignal/appsignal-elixir-phoenix/commit/46c4ede56116e5f3d04d8ee76767d7178fa0cd63)

Two of the test matrix entries resolved a version of Plug that their
Elixir version cannot compile.

The Elixir 1.14 entries had no Plug version set at all, so they resolved
Plug 1.20, which requires Elixir 1.15 or newer. Pin them to Plug 1.19,
which is the newest series that still supports Elixir 1.14.

The Elixir 1.11 entries were pinned to Plug 1.18, but Plug 1.18.2 calls
`Kernel.then/2`, which was added in Elixir 1.12. Plug 1.18 still
declares support for Elixir 1.10 and newer, so this looks like an
oversight on its side rather than a deliberate change. Hold those
entries below 1.18.2.

[skip changeset]
