### PR TITLE
Add an option to only report failed Phoenix requests

### DIFF
--- a/.changesets/add-an-option-to-only-report-failed-phoenix-requests.md
+++ b/.changesets/add-an-option-to-only-report-failed-phoenix-requests.md
@@ -1,0 +1,24 @@
+---
+bump: minor
+type: add
+---
+
+Add the `phoenix_errors_only` option. When it is enabled, a Phoenix request is
+only reported when it raises an exception. Requests that succeed are not
+reported at all, which reduces the number of samples the integration sends:
+
+```elixir
+config :appsignal, :config,
+  otp_app: :my_app,
+  name: "my_app",
+  phoenix_errors_only: true
+```
+
+Because a successful request is not reported, instrumentation inside it is not
+reported either: an `Appsignal.instrument/2` call, an Ecto query, or a function
+decorated with `transaction_event()`. Requests that raise are reported in full,
+with their duration, action name, parameters, environment and session data
+unchanged.
+
+The option does not apply to applications that `use Appsignal.Plug`, which
+report the request themselves, or to LiveView and channel events.

--- a/.changesets/fix-null-response-status-on-reported-exceptions.md
+++ b/.changesets/fix-null-response-status-on-reported-exceptions.md
@@ -1,0 +1,15 @@
+---
+bump: patch
+type: fix
+---
+
+Fix the response status of a reported exception always being `null`. A Phoenix
+router emits its exception event before `Phoenix.Endpoint.RenderErrors` renders
+and sends the response, so the conn carries no status yet, and both the
+`response_status` in the sample's metadata and the `status` in its environment
+were reported as `null`.
+
+The status is now taken from the exception itself, as AppSignal for Plug already
+does: the `:plug_status` the exception carries, such as 404 for
+`Ecto.NoResultsError`, and 500 for an exception that carries none. Requests that
+do not raise keep reporting the status of the response they sent.

--- a/lib/appsignal_phoenix.ex
+++ b/lib/appsignal_phoenix.ex
@@ -15,6 +15,24 @@ defmodule Appsignal.Phoenix do
         # ...
       end
 
+  ## Only reporting requests that fail
+
+  Set the `phoenix_errors_only` option to report a request only when it raises
+  an exception. Requests that succeed are not reported at all, which reduces the
+  number of samples this integration sends:
+
+      config :appsignal, :config,
+        otp_app: :my_app,
+        name: "my_app",
+        phoenix_errors_only: true
+
+  Because a successful request is not reported, instrumentation inside it is not
+  reported either: an `Appsignal.instrument/2` call, an Ecto query, or a function
+  decorated with `transaction_event()`. Requests that raise are reported in full.
+
+  The option does not apply to applications that `use Appsignal.Plug`, which
+  report the request themselves, or to LiveView and channel events.
+
   """
 
   @deprecated "Since AppSignal for Phoenix 2.3.0, Phoenix instrumentation is up automatically. The `use Appsignal.Phoenix` line is no longer needed and should be removed from your app's endpoint file."

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -162,7 +162,7 @@ defmodule Appsignal.Phoenix.EventHandler do
   defp do_add_error(span, conn, reason, stack) do
     span
     |> @span.add_error(:error, reason, stack)
-    |> set_span_data(%{conn: conn})
+    |> set_span_data(%{conn: put_error_status(conn, reason)})
     |> @tracer.close_span()
 
     # No stop event arrives for the spans this request opened, so nothing else
@@ -211,6 +211,28 @@ defmodule Appsignal.Phoenix.EventHandler do
       :ok
     end
   end
+
+  # The router emits its exception event before `Phoenix.Endpoint.RenderErrors`
+  # renders and sends the response, so the conn carries no status yet, and the
+  # reported response status would be `nil`. Take it from the exception instead,
+  # the way `Appsignal.Plug.handle_error/5` does: `Plug.Exception.status/1`
+  # returns the `:plug_status` the exception carries, such as 404 for
+  # `Ecto.NoResultsError`, and 500 for anything that carries none.
+  #
+  # A conn that has sent its response already carries its real status, and
+  # `Plug.Conn.put_status/2` raises for one. A `:telemetry` handler that raises is
+  # detached for good, which would take error reporting with it, so only a conn
+  # that has not sent anything is touched. These are the states
+  # `Plug.Conn.put_status/2` accepts; a version of Plug that knows fewer of them
+  # cannot produce the ones it does not know.
+  @unsent_conn_states [:unset, :set, :set_upgrade, :set_chunked, :set_file]
+
+  defp put_error_status(%Plug.Conn{state: state} = conn, reason)
+       when state in @unsent_conn_states do
+    Plug.Conn.put_status(conn, Plug.Exception.status(reason))
+  end
+
+  defp put_error_status(conn, _reason), do: conn
 
   defp set_span_data(span, %{conn: conn} = metadata) do
     appsignal_metadata = Appsignal.Metadata.metadata(conn)

--- a/lib/appsignal_phoenix/event_handler.ex
+++ b/lib/appsignal_phoenix/event_handler.ex
@@ -18,6 +18,10 @@ defmodule Appsignal.Phoenix.EventHandler do
   @route_key {__MODULE__, :route}
   @root_span_data_key {__MODULE__, :root_span_data_set}
 
+  # Whether this request is discarded unless it fails, which is what the
+  # `phoenix_errors_only` option asks for.
+  @discard_key {__MODULE__, :discard}
+
   def attach do
     handlers = %{
       [:phoenix, :endpoint, :start] => &__MODULE__.phoenix_endpoint_start/4,
@@ -55,6 +59,8 @@ defmodule Appsignal.Phoenix.EventHandler do
 
     parent = @tracer.current_span()
 
+    _ = start_discarding(parent)
+
     "http_request"
     |> @tracer.create_span(parent)
     |> @span.set_attribute("appsignal:category", "call.phoenix_endpoint")
@@ -64,14 +70,26 @@ defmodule Appsignal.Phoenix.EventHandler do
   def phoenix_endpoint_stop(_event, _measurements, metadata, _config) do
     span = pop(@endpoint_key)
 
-    # This event fires from a `register_before_send` callback, so it arrives
-    # before the router dispatch stop event does. The root span has to be
-    # described here, because it is closed below and cannot be described
-    # afterwards.
-    _ = Process.put(@root_span_data_key, true)
-    _root_span = set_span_data(@tracer.root_span(), with_route(metadata))
+    if discard?() do
+      # This request is not reported, so its root span is neither closed nor
+      # described. Describing it means building the params, environment and
+      # session sample data for a trace that is thrown away.
+      #
+      # An exception arriving after this event, raised by code that runs after
+      # the response was sent, still finds the span in the registry:
+      # `do_add_error/4` describes and closes it, and the request is reported
+      # after all.
+      discard_spans()
+    else
+      # This event fires from a `register_before_send` callback, so it arrives
+      # before the router dispatch stop event does. The root span has to be
+      # described here, because it is closed below and cannot be described
+      # afterwards.
+      _ = Process.put(@root_span_data_key, true)
+      _root_span = set_span_data(@tracer.root_span(), with_route(metadata))
 
-    @tracer.close_span(span)
+      @tracer.close_span(span)
+    end
   end
 
   def phoenix_router_dispatch_start(_event, _measurements, metadata, _config) do
@@ -87,6 +105,8 @@ defmodule Appsignal.Phoenix.EventHandler do
 
     parent = @tracer.current_span()
 
+    _ = start_discarding(parent)
+
     "http_request"
     |> @tracer.create_span(parent)
     |> @span.set_attribute("appsignal:category", "call.phoenix_router_dispatch")
@@ -96,12 +116,16 @@ defmodule Appsignal.Phoenix.EventHandler do
   def phoenix_router_dispatch_stop(_event, _measurements, metadata, _config) do
     span = pop(@dispatch_key)
 
-    # A Phoenix router can be dispatched to without a Phoenix endpoint, for
-    # example when a Plug application forwards to one. There is no endpoint stop
-    # event to describe the root span then, so this handler does it instead.
-    _root_span = set_root_span_data_unless_set(metadata)
+    if discard?() do
+      discard_spans()
+    else
+      # A Phoenix router can be dispatched to without a Phoenix endpoint, for
+      # example when a Plug application forwards to one. There is no endpoint stop
+      # event to describe the root span then, so this handler does it instead.
+      _root_span = set_root_span_data_unless_set(metadata)
 
-    @tracer.close_span(span)
+      @tracer.close_span(span)
+    end
   end
 
   def phoenix_router_dispatch_exception(
@@ -150,26 +174,42 @@ defmodule Appsignal.Phoenix.EventHandler do
   end
 
   def phoenix_template_render_start(_event, _measurements, metadata, _config) do
-    parent = @tracer.current_span()
+    if discard?() do
+      # A span opened here would be a child of a root span that is discarded, so
+      # it is not reported either way. Nothing is pushed, so that the stop
+      # handler has nothing to pop.
+      :ok
+    else
+      parent = @tracer.current_span()
 
-    _ =
-      @span.set_sample_data_if_nil(@tracer.root_span(), "tags", %{
-        "phoenix_template" => metadata.template,
-        "phoenix_format" => metadata.format,
-        "phoenix_view" => module_name(metadata.view)
-      })
+      _ =
+        @span.set_sample_data_if_nil(@tracer.root_span(), "tags", %{
+          "phoenix_template" => metadata.template,
+          "phoenix_format" => metadata.format,
+          "phoenix_view" => module_name(metadata.view)
+        })
 
-    "http_request"
-    |> @tracer.create_span(parent)
-    |> @span.set_name(
-      "Render #{inspect(metadata.template)} (#{metadata.format}) template from #{module_name(metadata.view)}"
-    )
-    |> @span.set_attribute("appsignal:category", "render.phoenix_template")
-    |> push(@render_key)
+      _ =
+        "http_request"
+        |> @tracer.create_span(parent)
+        |> @span.set_name(
+          "Render #{inspect(metadata.template)} (#{metadata.format}) template from #{module_name(metadata.view)}"
+        )
+        |> @span.set_attribute("appsignal:category", "render.phoenix_template")
+        |> push(@render_key)
+
+      :ok
+    end
   end
 
   def phoenix_template_render_stop(_event, _measurements, _metadata, _config) do
-    @tracer.close_span(pop(@render_key))
+    if discard?() do
+      :ok
+    else
+      _ = @tracer.close_span(pop(@render_key))
+
+      :ok
+    end
   end
 
   defp set_span_data(span, %{conn: conn} = metadata) do
@@ -213,6 +253,68 @@ defmodule Appsignal.Phoenix.EventHandler do
     _ = Process.delete(@route_key)
 
     :ok
+  end
+
+  # Decides whether this request is reported only if it fails, and remembers the
+  # decision for the rest of it: the configuration could change halfway through a
+  # request, and the stop handlers have to agree with the start handlers.
+  #
+  # Only the first span this handler opens for a request decides. A router
+  # dispatch inside an endpoint, or a forwarded router dispatch, must not decide
+  # again: its parent is a span this handler opened itself. Empty stacks mean no
+  # request of ours is in flight, so nothing an earlier request decided leaks
+  # into this one.
+  #
+  # A request whose root span was opened elsewhere, such as by `Appsignal.Plug`,
+  # is never discarded. That span is reported either way, and leaving a child of
+  # it unclosed would only make the trace incomplete.
+  defp start_discarding(parent) do
+    if no_spans_open?() do
+      _ = Process.put(@discard_key, is_nil(parent) and errors_only?())
+    end
+
+    :ok
+  end
+
+  defp discard?, do: Process.get(@discard_key) == true
+
+  # Takes this request's spans out of the registry without closing them, once the
+  # last span this handler opened for it is done. Nothing is sent: a trace leaves
+  # the extension only when its root span closes, and the extension frees a span
+  # it never closed once the last reference to it is garbage collected.
+  #
+  # They cannot be left in the registry. On a web server that serves more than
+  # one request per process, such as Bandit, the next request would find this
+  # request's root span, open its own spans as children of a span that never
+  # closes, and go unreported as well.
+  #
+  # The endpoint stop event fires from a `register_before_send` callback, so it
+  # arrives while the router dispatch is still open. It discards nothing then,
+  # and the router dispatch stop event does it instead.
+  #
+  # `Appsignal.Tracer.delete/1` is called directly, rather than through the
+  # `@tracer` module attribute, because `Appsignal.Test.Tracer` does not wrap it.
+  # Both write to the same registry table, so this behaves the same under test.
+  defp discard_spans do
+    if no_spans_open?() do
+      _ = Appsignal.Tracer.delete(self())
+
+      forget()
+    end
+
+    :ok
+  end
+
+  defp no_spans_open? do
+    Process.get(@endpoint_key, []) == [] and Process.get(@dispatch_key, []) == []
+  end
+
+  # Read from the AppSignal configuration at runtime, so that it can be set from
+  # a release's runtime configuration. `Appsignal.Config` merges the application's
+  # configuration over its defaults and keeps the keys it does not know about, so
+  # this works without a change to the AppSignal package.
+  defp errors_only? do
+    Application.get_env(:appsignal, :config, [])[:phoenix_errors_only] == true
   end
 
   defp set_root_span_data_unless_set(metadata) do
@@ -261,7 +363,14 @@ defmodule Appsignal.Phoenix.EventHandler do
 
   defp forget do
     Enum.each(
-      [@endpoint_key, @dispatch_key, @render_key, @route_key, @root_span_data_key],
+      [
+        @endpoint_key,
+        @dispatch_key,
+        @render_key,
+        @route_key,
+        @root_span_data_key,
+        @discard_key
+      ],
       &Process.delete/1
     )
   end

--- a/test/appsignal_phoenix/event_handler_errors_only_test.exs
+++ b/test/appsignal_phoenix/event_handler_errors_only_test.exs
@@ -1,0 +1,311 @@
+defmodule Appsignal.Phoenix.EventHandlerErrorsOnlyTest do
+  # Tests the event handler with the `phoenix_errors_only` option enabled, where
+  # a request is only reported when it fails. A successful request still opens
+  # its spans, but its root span is never closed, so the trace is never sent.
+  use ExUnit.Case
+  alias Appsignal.{Span, Test, Tracer}
+
+  setup do
+    start_supervised!(Test.Tracer)
+    start_supervised!(Test.Span)
+
+    config = Application.get_env(:appsignal, :config)
+
+    Application.put_env(
+      :appsignal,
+      :config,
+      Enum.into(config, %{phoenix_errors_only: true})
+    )
+
+    on_exit(fn -> Application.put_env(:appsignal, :config, config) end)
+
+    :ok
+  end
+
+  describe "after a successful request" do
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+      render_start()
+      render_stop()
+      endpoint_stop()
+      router_dispatch_stop()
+    end
+
+    test "opens the endpoint and the router dispatch span" do
+      assert {:ok, [{"http_request", %Span{}}, {"http_request", nil}]} =
+               Test.Tracer.get(:create_span)
+    end
+
+    test "does not open a render span" do
+      {:ok, calls} = Test.Tracer.get(:create_span)
+
+      assert length(calls) == 2
+    end
+
+    test "does not close any span" do
+      assert :error == Test.Tracer.get(:close_span)
+    end
+
+    test "does not describe the root span" do
+      assert :error == Test.Span.get(:set_sample_data_if_nil)
+      assert :error == Test.Span.get(:set_sample_data)
+      assert :error == Test.Span.get(:set_name_if_nil)
+    end
+
+    test "leaves no spans behind" do
+      assert [] == Tracer.lookup(self())
+    end
+  end
+
+  describe "after a successful request that is halted before it reaches the router" do
+    setup do
+      endpoint_start()
+      endpoint_stop()
+    end
+
+    test "does not close any span" do
+      assert :error == Test.Tracer.get(:close_span)
+    end
+
+    test "leaves no spans behind" do
+      assert [] == Tracer.lookup(self())
+    end
+  end
+
+  describe "after a successful request without an endpoint" do
+    # A Plug application that forwards to a Phoenix router emits the router
+    # dispatch events without the endpoint ones.
+    setup do
+      router_dispatch_start()
+      router_dispatch_stop()
+    end
+
+    test "does not close any span" do
+      assert :error == Test.Tracer.get(:close_span)
+    end
+
+    test "leaves no spans behind" do
+      assert [] == Tracer.lookup(self())
+    end
+  end
+
+  describe "after a successful request through a forwarded router" do
+    # `Phoenix.Router.forward` re-enters the router, so the router dispatch
+    # events nest. Only the outermost dispatch stop discards the request.
+    test "discards the request when the outermost dispatch is done" do
+      endpoint_start()
+      router_dispatch_start()
+      router_dispatch_start()
+      endpoint_stop()
+
+      router_dispatch_stop()
+      assert [_ | _] = Tracer.lookup(self())
+
+      router_dispatch_stop()
+      assert [] == Tracer.lookup(self())
+
+      assert :error == Test.Tracer.get(:close_span)
+    end
+  end
+
+  describe "after a successful request, then another in the same process" do
+    # Bandit serves every keep-alive request on a connection from one process.
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+      endpoint_stop()
+      router_dispatch_stop()
+
+      endpoint_start()
+    end
+
+    test "opens a root span for the second request" do
+      # `Appsignal.Test.Tracer` records calls with the most recent one first.
+      assert {:ok, [{"http_request", nil} | _]} = Test.Tracer.get(:create_span)
+    end
+  end
+
+  describe "after a request that raises" do
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+      router_dispatch_exception()
+    end
+
+    test "sets the root span's name" do
+      assert {:ok, [{%Span{}, "AppsignalPhoenixExampleWeb.PageController#index"}]} =
+               Test.Span.get(:set_name_if_nil)
+    end
+
+    test "sets the root span's error" do
+      assert {:ok, [{%Span{}, :error, %RuntimeError{}, []}]} = Test.Span.get(:add_error)
+    end
+
+    test "sets the root span's sample data" do
+      {:ok, calls} = Test.Span.get(:set_sample_data_if_nil)
+
+      assert [{%Span{}, "params", %{"foo" => "bar"}}] =
+               Enum.filter(calls, fn {_span, key, _value} -> key == "params" end)
+    end
+
+    test "closes the root span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+
+    test "ignores the process" do
+      assert [{_pid, :ignore}] = Tracer.lookup(self())
+    end
+  end
+
+  describe "after a request that raises once its response was sent" do
+    # The endpoint stop event fires from a `register_before_send` callback, so it
+    # arrives before the router dispatch is done. It must not discard the spans
+    # of a request that can still fail.
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+      endpoint_stop()
+      router_dispatch_exception()
+    end
+
+    test "sets the root span's error" do
+      assert {:ok, [{%Span{}, :error, %RuntimeError{}, []}]} = Test.Span.get(:add_error)
+    end
+
+    test "closes the root span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
+  describe "after a request that raises without an endpoint" do
+    setup do
+      router_dispatch_start()
+      router_dispatch_exception()
+    end
+
+    test "sets the root span's error" do
+      assert {:ok, [{%Span{}, :error, %RuntimeError{}, []}]} = Test.Span.get(:add_error)
+    end
+
+    test "closes the root span" do
+      assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
+    end
+  end
+
+  describe "after a successful request whose root span was opened elsewhere" do
+    # The shape of an application that uses `Appsignal.Plug`, which opens the
+    # root span itself and reports the request either way. Discarding the spans
+    # this handler opens would only leave that trace incomplete.
+    setup do
+      root_span = Tracer.create_span("http_request")
+
+      endpoint_start()
+      router_dispatch_start()
+      render_start()
+      render_stop()
+      endpoint_stop()
+      router_dispatch_stop()
+
+      [root_span: root_span]
+    end
+
+    test "closes the spans it opened" do
+      {:ok, calls} = Test.Tracer.get(:close_span)
+
+      assert length(calls) == 3
+    end
+
+    test "describes the root span" do
+      {:ok, calls} = Test.Span.get(:set_sample_data_if_nil)
+
+      assert [{%Span{}, "params", %{"foo" => "bar"}}] =
+               Enum.filter(calls, fn {_span, key, _value} -> key == "params" end)
+    end
+
+    test "leaves the root span in the registry", %{root_span: root_span} do
+      assert [{_pid, ^root_span}] = Tracer.lookup(self())
+    end
+  end
+
+  defp endpoint_start do
+    :telemetry.execute(
+      [:phoenix, :endpoint, :start],
+      %{system_time: -576_460_736_044_040_000},
+      %{conn: %Plug.Conn{private: %{phoenix_endpoint: PhoenixWeb.Endpoint}}, options: []}
+    )
+  end
+
+  defp endpoint_stop do
+    :telemetry.execute(
+      [:phoenix, :endpoint, :stop],
+      %{duration: 49_474_000},
+      %{conn: conn(), options: []}
+    )
+  end
+
+  defp router_dispatch_start do
+    :telemetry.execute(
+      [:phoenix, :router_dispatch, :start],
+      %{system_time: -576_460_736_044_040_000},
+      %{
+        conn: %Plug.Conn{private: %{phoenix_endpoint: PhoenixWeb.Endpoint}},
+        plug: AppsignalPhoenixExampleWeb.PageController,
+        plug_opts: :index,
+        route: "/",
+        path_params: %{},
+        pipe_through: [:browser],
+        log: :info
+      }
+    )
+  end
+
+  defp router_dispatch_stop do
+    :telemetry.execute(
+      [:phoenix, :router_dispatch, :stop],
+      %{duration: 49_474_000},
+      %{
+        conn: conn(),
+        plug: AppsignalPhoenixExampleWeb.PageController,
+        plug_opts: :index,
+        route: "/foo/:bar",
+        path_params: %{},
+        pipe_through: [:browser],
+        log: :info
+      }
+    )
+  end
+
+  defp router_dispatch_exception do
+    :telemetry.execute(
+      [:phoenix, :router_dispatch, :exception],
+      %{duration: 49_474_000},
+      %{conn: conn(), reason: %RuntimeError{}, stacktrace: [], options: []}
+    )
+  end
+
+  defp render_start do
+    :telemetry.execute(
+      [:phoenix, :controller, :render, :start],
+      %{system_time: -576_460_736_044_040_000},
+      %{view: PhoenixWeb.View, template: "template", format: "html"}
+    )
+  end
+
+  defp render_stop do
+    :telemetry.execute([:phoenix, :controller, :render, :stop], %{duration: 49_474_000}, %{})
+  end
+
+  defp conn do
+    %Plug.Conn{
+      params: %{"foo" => "bar"},
+      private: %{
+        phoenix_action: :index,
+        phoenix_controller: AppsignalPhoenixExampleWeb.PageController
+      },
+      port: 80,
+      request_path: "/",
+      status: 200
+    }
+  end
+end

--- a/test/appsignal_phoenix/event_handler_errors_only_test.exs
+++ b/test/appsignal_phoenix/event_handler_errors_only_test.exs
@@ -153,8 +153,59 @@ defmodule Appsignal.Phoenix.EventHandlerErrorsOnlyTest do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
     end
 
+    test "sets the root span's response status" do
+      {:ok, calls} = Test.Span.get(:set_sample_data)
+
+      [{%Span{}, "metadata", metadata}] =
+        Enum.filter(calls, fn {_span, key, _value} -> key == "metadata" end)
+
+      assert 500 == metadata["response_status"]
+    end
+
     test "ignores the process" do
       assert [{_pid, :ignore}] = Tracer.lookup(self())
+    end
+  end
+
+  describe "after a request that raises an exception with a status" do
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+      router_dispatch_exception(conn(), Plug.BadRequestError.exception([]))
+    end
+
+    test "sets the root span's response status to the exception's status" do
+      {:ok, calls} = Test.Span.get(:set_sample_data)
+
+      [{%Span{}, "metadata", metadata}] =
+        Enum.filter(calls, fn {_span, key, _value} -> key == "metadata" end)
+
+      assert 400 == metadata["response_status"]
+    end
+  end
+
+  describe "after a request that raises with a conn that already sent its response" do
+    # `Plug.Conn.put_status/2` raises for a conn that has sent its response, and
+    # a `:telemetry` handler that raises is detached for good. The conn carries
+    # its real status by then, so it is left alone.
+    setup do
+      endpoint_start()
+      router_dispatch_start()
+      endpoint_stop()
+      router_dispatch_exception(%{conn() | state: :sent, status: 204}, %RuntimeError{})
+    end
+
+    test "sets the root span's error" do
+      assert {:ok, [{%Span{}, :error, %RuntimeError{}, []}]} = Test.Span.get(:add_error)
+    end
+
+    test "keeps the response status the conn was sent with" do
+      {:ok, calls} = Test.Span.get(:set_sample_data)
+
+      [{%Span{}, "metadata", metadata}] =
+        Enum.filter(calls, fn {_span, key, _value} -> key == "metadata" end)
+
+      assert 204 == metadata["response_status"]
     end
   end
 
@@ -276,11 +327,11 @@ defmodule Appsignal.Phoenix.EventHandlerErrorsOnlyTest do
     )
   end
 
-  defp router_dispatch_exception do
+  defp router_dispatch_exception(conn \\ conn(), reason \\ %RuntimeError{}) do
     :telemetry.execute(
       [:phoenix, :router_dispatch, :exception],
       %{duration: 49_474_000},
-      %{conn: conn(), reason: %RuntimeError{}, stacktrace: [], options: []}
+      %{conn: conn, reason: reason, stacktrace: [], options: []}
     )
   end
 

--- a/test/appsignal_phoenix/event_handler_test.exs
+++ b/test/appsignal_phoenix/event_handler_test.exs
@@ -162,8 +162,85 @@ defmodule Appsignal.Phoenix.EventHandlerTest do
                "port" => 80,
                "request_id" => nil,
                "request_path" => "/",
-               "status" => 200
+               "status" => 500
              } == environment
+    end
+
+    test "sets the root span's response status" do
+      {:ok, calls} = Test.Span.get(:set_sample_data)
+
+      [{%Span{}, "metadata", metadata}] =
+        Enum.filter(calls, fn {_span, key, _value} -> key == "metadata" end)
+
+      assert 500 == metadata["response_status"]
+    end
+  end
+
+  describe "after receiving a router_dispatch-exception event for an exception with a status" do
+    setup [:create_root_span, :router_dispatch_start_event]
+
+    setup do
+      :telemetry.execute(
+        [:phoenix, :router_dispatch, :exception],
+        %{duration: 49_474_000},
+        %{
+          conn: conn(),
+          reason: Plug.BadRequestError.exception([]),
+          stacktrace: [],
+          options: []
+        }
+      )
+    end
+
+    test "sets the root span's response status to the exception's status" do
+      {:ok, calls} = Test.Span.get(:set_sample_data)
+
+      [{%Span{}, "metadata", metadata}] =
+        Enum.filter(calls, fn {_span, key, _value} -> key == "metadata" end)
+
+      assert 400 == metadata["response_status"]
+    end
+
+    test "sets the root span's sample data" do
+      {:ok, calls} = Test.Span.get(:set_sample_data_if_nil)
+
+      [{%Span{}, "environment", environment}] =
+        Enum.filter(calls, fn {_span, key, _value} -> key == "environment" end)
+
+      assert 400 == environment["status"]
+    end
+  end
+
+  describe "after receiving a router_dispatch-exception event for a conn that sent its response" do
+    # `Plug.Conn.put_status/2` raises for a conn that has sent its response, and
+    # a `:telemetry` handler that raises is detached for good. The conn carries
+    # its real status by then, so it is left alone.
+    setup [:create_root_span, :router_dispatch_start_event]
+
+    setup do
+      :telemetry.execute(
+        [:phoenix, :router_dispatch, :exception],
+        %{duration: 49_474_000},
+        %{
+          conn: %{conn() | state: :sent, status: 204},
+          reason: %RuntimeError{},
+          stacktrace: [],
+          options: []
+        }
+      )
+    end
+
+    test "sets the root span's error" do
+      assert {:ok, [{%Span{}, :error, %RuntimeError{}, []}]} = Test.Span.get(:add_error)
+    end
+
+    test "keeps the response status the conn was sent with" do
+      {:ok, calls} = Test.Span.get(:set_sample_data)
+
+      [{%Span{}, "metadata", metadata}] =
+        Enum.filter(calls, fn {_span, key, _value} -> key == "metadata" end)
+
+      assert 204 == metadata["response_status"]
     end
   end
 


### PR DESCRIPTION
Two commits: an option to stop reporting requests that succeed, and a fix for the response status of a reported exception always being `null`.

## Add an option to only report failed Phoenix requests

With `phoenix_errors_only` enabled, a Phoenix request is reported only when it raises. Requests that succeed are not reported at all, which cuts the number of samples the integration sends:

```elixir
config :appsignal, :config,
  otp_app: :my_app,
  name: "my_app",
  phoenix_errors_only: true
```

### How

The start handlers are untouched: the spans are still opened where they were. Only the stop handlers change — they do not close the root span of a request that succeeded, and take the request's spans out of the registry instead.

This rests on two properties of the extension:

- A trace leaves the extension only when its root span closes. `Appsignal.Span.close/1` calls `Nif.close_span/1` (`c_src/appsignal_extension.c` `_close_span`), the only caller of `appsignal_close_span`. An unclosed root span is never sent.
- An unclosed span is freed, not leaked. The span reference is an `ErlNifResourceType` whose destructor (`destruct_appsignal_span`) calls `appsignal_free_span`, so a discarded span is freed once its last reference is garbage collected.

Keeping the spans open until then is what keeps the change small:

- `phoenix_router_dispatch_exception` is unchanged. The root span is there, so a failed request is reported in full — duration, action name, parameters, environment and session data — including one that raises after its response was sent.
- Every other integration (`Appsignal.Ecto`, `Appsignal.Instrumentation`, Finch, Absinthe) keeps parenting its spans to a real current span, so none of them becomes a root span, and a sample, of its own. No `Appsignal.Tracer.ignore/0` is needed, and LiveView, channels and websocket upgrades are untouched.
- `Appsignal.Error.Backend` still finds the span if the process crashes outside the router.

Two details worth reviewing:

- `start_discarding/1` decides once per request, when no span this handler opened is still open. Deciding again at the router dispatch start event would see the endpoint span as its parent and get the wrong answer, and the empty stacks are what keep an earlier request's decision from leaking into this one.
- `discard_spans/0` has to deregister, not only skip the close. Leaving the root span in the registry means the next request on a Bandit connection opens its spans as children of a span that never closes, and goes unreported as well — the failure mode fixed in 88658db.

A request whose root span was opened elsewhere, such as by `Appsignal.Plug`, is never discarded: that span is reported either way, and leaving a child of it unclosed would only make the trace incomplete.

The render handlers are guarded on both sides, which saves a span and a sample-data map per render. They are children of a discarded root span, so they were never reported either way.

### Trade-off

A discarded request still does the in-process work of creating and freeing its spans in the extension, and still creates a child span per Ecto query and per `Appsignal.instrument/2` call. No network traffic and no cost, but not free either.

Removing that as well means never opening the spans, which needs `Appsignal.Tracer.ignore/0` for the duration of the request — and that ignore cannot start at the endpoint start event, because `plug :socket_dispatch` is the last plug in a Phoenix endpoint, so that event fires for websocket upgrades too, and an upgrade sends no response and therefore has no stop event to lift the ignore. Every LiveView and channel connection process would stay ignored for its lifetime. Happy to take that route instead if you would rather have the overhead gone, but it is a much larger change for a handful of extension calls per request.

## Report the status of an exception the request ends with

The response status of a reported exception was always `null`. A Phoenix router emits its exception event from inside the dispatch, before `Phoenix.Endpoint.RenderErrors` renders and sends the response, so the conn carries no status yet. `Appsignal.Metadata` reads `conn.status`, so both the `response_status` in the sample's metadata and the `status` in its environment came out as `null`.

The status now comes from the exception, the way `Appsignal.Plug.handle_error/5` already derives it: `Plug.Exception.status/1` returns the `:plug_status` the exception carries, such as 404 for `Ecto.NoResultsError`, and 500 for an exception that carries none. Only the error path is affected; the endpoint and router dispatch stop events describe the span from a conn whose response was sent, and keep reporting the status it was sent with.

`Plug.Conn.put_status/2` raises for a conn that has sent its response, and a `:telemetry` handler that raises is detached for good, which would take error reporting with it. Such a conn already carries its real status, so it is left alone. The guard is a whitelist of the states `Plug.Conn.put_status/2` accepts rather than a check against `:sent`, because `:chunked` and `:upgraded` raise as well.

This changed one existing assertion, in the exception describe of `event_handler_test.exs`: it asserted a `status` of 200, which its conn fixture happens to carry and a real error-path conn does not.

## Tests

155 tests, 0 failures. `mix format --check-formatted`, `mix credo --strict` and `mix dialyzer` are clean.

`test/appsignal_phoenix/event_handler_errors_only_test.exs` covers the new option: a successful request, one halted before the router, a dispatch without an endpoint (a Plug application forwarding in), a forwarded router dispatch discarding on the outermost stop only, two requests in the same process, a request that raises, one that raises after its response was sent, one that raises without an endpoint, and a request whose root span was opened elsewhere.

The rest of the suite is unmodified and passes with the option off. Verified the new tests are not vacuous: with `errors_only?/0` forced to `false`, 8 of its 23 tests fail.

The status fix is covered on both paths — a generic raise reporting 500, an exception carrying `:plug_status` reporting that status, and an already-sent conn keeping its own status with the error still recorded, which doubles as the guard that nothing raises.

## Notes

- The option is read straight from the AppSignal config, which works because `Appsignal.Config` keeps keys it does not know about. Registering `phoenix_errors_only` in the `appsignal` package's `@default_config` and `@env_to_key_mapping` would make it documented, diagnosable and settable through `APPSIGNAL_PHOENIX_ERRORS_ONLY`. Happy to open that PR if you want the option to land this way.
- `discard_spans/0` calls `Appsignal.Tracer.delete/1` directly rather than through the `@tracer` module attribute, because `Appsignal.Test.Tracer` does not wrap `delete/1`. A `defdelegate` there would let it go through `@tracer`.
- I have run this against the test suite and dialyzer, but not yet against a real agent under sustained load. Worth confirming that discarded spans are collected and that failed requests still arrive complete before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
